### PR TITLE
Modify Gen combinators so that they take a Range

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ The key improvement is that shrinking comes for free — instead of generating a
 * [Credits](#credits)
 * [License](https://github.com/hedgehogqa/fsharp-hedgehog/blob/master/LICENSE)
 
+---
+
+**Important: The samples on this README are based on [Hedgehog 0.1.0](https://www.nuget.org/packages/Hedgehog/0.1.0). See [versioning](#versioning) to learn more about Hedgehog's versioning strategy.**
+
+---
+
 ## Highlights
 
 * Shrinking is baked into the `Gen` type, so you get it for free. This is not a trivial distinction. Integrating shrinking into generation has two large benefits:

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -420,7 +420,7 @@ module Gen =
         let yMax = System.DateTime.MaxValue.Year
         gen {
             let! y =
-                integral <| Range.constantFrom 2000 yMin yMax
+                integral <| Range.linearFrom 2000 yMin yMax
             let! m =
                 integral <| Range.constant 1 12
             let! d =

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -165,13 +165,6 @@ module Gen =
     let inline integral (range : Range<'a>) : Gen<'a> =
         create (Shrink.towards <| Range.origin range) (Random.integral range)
 
-    /// Generates a random number from the whole range of the numeric type.
-    let inline bounded () : Gen<'a> =
-        let zero = LanguagePrimitives.GenericZero
-        let range = Range.constantBounded ()
-
-        create (Shrink.towards zero) (Random.integral range)
-
     //
     // Combinators - Choice
     //
@@ -445,7 +438,7 @@ module Gen =
 
     /// Generates a random globally unique identifier.
     let guid : Gen<System.Guid> =
-        gen { let! bs = array' 16 16 <| bounded ()
+        gen { let! bs = array' 16 16 (byte <| Range.constantBounded ())
               return System.Guid bs }
 
     /// Generates a random instant in time expressed as a date and time of day.

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -317,26 +317,26 @@ module Gen =
     //
 
     // Generates a random character in the specified range.
-    let charRange (lo : char) (hi : char) : Gen<char> =
+    let char (lo : char) (hi : char) : Gen<char> =
         integral <| Range.constant (int lo) (int hi) |> map char
 
     /// Generates a random character.
-    let char : Gen<char> =
+    let charBounded : Gen<char> =
         let lo = System.Char.MinValue
         let hi = System.Char.MaxValue
-        charRange lo hi
+        char lo hi
 
     // Generates a random digit.
     let digit : Gen<char> =
-        charRange '0' '9'
+        char '0' '9'
 
     // Generates a random lowercase character.
     let lower : Gen<char> =
-        charRange 'a' 'z'
+        char 'a' 'z'
 
     // Generates a random uppercase character.
     let upper : Gen<char> =
-        charRange 'A' 'Z'
+        char 'A' 'Z'
 
     // Generates a random alpha character.
     let alpha : Gen<char> =
@@ -354,7 +354,7 @@ module Gen =
 
     /// Generates a random string.
     let string : Gen<string> =
-        choice [alphaNum; char] |> string'
+        choice [alphaNum; charBounded] |> string'
 
     //
     // Combinators - Primitives

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -294,7 +294,7 @@ module Gen =
         n = 0 || not (List.isEmpty (List.skip (n - 1) xs))
 
     /// Generates a list using a 'Range' to determine the length.
-    let list' (range : Range<int>) (g : Gen<'a>) : Gen<List<'a>> =
+    let list (range : Range<int>) (g : Gen<'a>) : Gen<List<'a>> =
         ofRandom
         <| (Random.sized
         <| fun size -> random {
@@ -304,43 +304,33 @@ module Gen =
                    |> Tree.filter (atLeast (Range.lowerBound size range))
            })
 
-    /// Generates a list of random length. The maximum length depends on the
-    /// size parameter.
-    let list (g : Gen<'a>) : Gen<List<'a>> =
-        sized (fun size -> list' (Range.constant 0 size) g)
-
-    /// Generates a non-empty list of random length. The maximum length depends
-    /// on the size parameter.
-    let list1 (g : Gen<'a>) : Gen<List<'a>> =
-        sized (fun size -> list' (Range.constant 1 size) g)
-
     /// Generates an array between 'n' and 'm' in length.
     let array' (n : int) (m : int) (g : Gen<'a>) : Gen<array<'a>> =
-        list' (Range.constant n m) g |> map Array.ofList
+        list (Range.constant n m) g |> map Array.ofList
 
     /// Generates an array of random length. The maximum length depends on the
     /// size parameter.
     let array (g : Gen<'a>) : Gen<array<'a>> =
-        list g |> map Array.ofList
+        sized (fun size -> list (Range.constant 0 size) g) |> map Array.ofList
 
     /// Generates a non-empty array of random length. The maximum length
     /// depends on the size parameter.
     let array1 (g : Gen<'a>) : Gen<array<'a>> =
-        list1 g |> map Array.ofList
+        sized (fun size -> list (Range.constant 1 size) g) |> map Array.ofList
 
     /// Generates a sequence between 'n' and 'm' in length.
     let seq' (n : int) (m : int) (g : Gen<'a>) : Gen<seq<'a>> =
-        list' (Range.constant n m) g |> map Seq.ofList
+        list (Range.constant n m) g |> map Seq.ofList
 
     /// Generates a sequence of random length. The maximum length depends on
     /// the size parameter.
     let seq (g : Gen<'a>) : Gen<seq<'a>> =
-        list g |> map Seq.ofList
+        sized (fun size -> list (Range.constant 0 size) g) |> map Seq.ofList
 
     /// Generates a non-empty sequence of random length. The maximum length
     /// depends on the size parameter.
     let seq1 (g : Gen<'a>) : Gen<seq<'a>> =
-        list1 g |> map Seq.ofList
+        sized (fun size -> list (Range.constant 1 size) g) |> map Seq.ofList
 
     //
     // Combinators - Characters

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -308,19 +308,9 @@ module Gen =
     let array (range : Range<int>) (g : Gen<'a>) : Gen<array<'a>> =
         list range g |> map Array.ofList
 
-    /// Generates a sequence between 'n' and 'm' in length.
-    let seq' (n : int) (m : int) (g : Gen<'a>) : Gen<seq<'a>> =
-        list (Range.constant n m) g |> map Seq.ofList
-
-    /// Generates a sequence of random length. The maximum length depends on
-    /// the size parameter.
-    let seq (g : Gen<'a>) : Gen<seq<'a>> =
-        sized (fun size -> list (Range.constant 0 size) g) |> map Seq.ofList
-
-    /// Generates a non-empty sequence of random length. The maximum length
-    /// depends on the size parameter.
-    let seq1 (g : Gen<'a>) : Gen<seq<'a>> =
-        sized (fun size -> list (Range.constant 1 size) g) |> map Seq.ofList
+    /// Generates a sequence using a 'Range' to determine the length.
+    let seq (range : Range<int>) (g : Gen<'a>) : Gen<seq<'a>> =
+        list range g |> map Seq.ofList
 
     //
     // Combinators - Characters

--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -55,8 +55,8 @@
     <Compile Include="Numeric.fs" />
     <Compile Include="Seed.fs" />
     <Compile Include="Tree.fs" />
-    <Compile Include="Random.fs" />
     <Compile Include="Range.fs" />
+    <Compile Include="Random.fs" />
     <Compile Include="Shrink.fs" />
     <Compile Include="Gen.fs" />
     <Compile Include="Property.fs" />

--- a/src/Hedgehog/Range.fs
+++ b/src/Hedgehog/Range.fs
@@ -2,6 +2,10 @@
 
 open Hedgehog.Numeric
 
+/// Tests are parameterized by the `Size` of the randomly-generated data,
+/// the meaning of which depends on the particular generator used.
+type Size = int
+
 /// A range describes the bounds of a number to generate, which may or may not
 /// be dependent on a 'Size'.
 type Range<'a> =

--- a/src/Hedgehog/Script.fsx
+++ b/src/Hedgehog/Script.fsx
@@ -36,7 +36,7 @@ Property.print <| property {
 //
 
 Property.print <| property {
-    let! xs = Gen.list <| Gen.bounded ()
+    let! xs = Gen.list <| Gen.int (Range.constantBounded ())
     return xs
             |> List.rev
             |> List.rev
@@ -155,7 +155,7 @@ Range.constantBounded ()
 //
 
 Gen.printSample <| gen {
-    let! addr = Gen.array' 4 4 <| Gen.bounded ()
+    let! addr = Gen.array' 4 4 (Gen.byte <| Range.constantBounded ())
     return System.Net.IPAddress addr
 }
 
@@ -190,7 +190,7 @@ let rec genExp =
     Gen.delay <| fun _ ->
     Gen.shrink shrinkExp <|
     Gen.choiceRec [
-        Lit <!> Gen.bounded ()
+        Lit <!> Gen.int (Range.constantBounded ())
     ] [
         Add <!> Gen.zip genExp genExp
     ]

--- a/src/Hedgehog/Script.fsx
+++ b/src/Hedgehog/Script.fsx
@@ -36,7 +36,7 @@ Property.print <| property {
 //
 
 Property.print <| property {
-    let! xs = Gen.list <| Gen.int (Range.constantBounded ())
+    let! xs = Gen.list (Range.linear 0 100) Gen.alpha
     return xs
             |> List.rev
             |> List.rev

--- a/src/Hedgehog/Script.fsx
+++ b/src/Hedgehog/Script.fsx
@@ -21,7 +21,7 @@ open System
 
 Property.print <| property {
     let! x = Gen.int <| Range.constant 1 100
-    let! ys = Gen.item ["a"; "b"; "c"; "d"] |> Gen.seq
+    let! ys = Gen.item ["a"; "b"; "c"; "d"] |> Gen.seq (Range.linear 0 100)
     counterexample (sprintf "tryHead ys = %A" <| Seq.tryHead ys)
     return x < 25 || Seq.length ys <= 3 || Seq.contains "a" ys
 }

--- a/src/Hedgehog/Script.fsx
+++ b/src/Hedgehog/Script.fsx
@@ -155,7 +155,8 @@ Range.constantBounded ()
 //
 
 Gen.printSample <| gen {
-    let! addr = Gen.array' 4 4 (Gen.byte <| Range.constantBounded ())
+    let! addr =
+        Gen.array (Range.constant 4 4) (Gen.byte <| Range.constantBounded ())
     return System.Net.IPAddress addr
 }
 

--- a/tests/Hedgehog.Tests/MinimalTests.fs
+++ b/tests/Hedgehog.Tests/MinimalTests.fs
@@ -55,7 +55,7 @@ let rec genExp : Gen<Exp> =
     Gen.delay <| fun _ ->
     Gen.shrink shrinkExp <| // comment this out to see the property fail
     Gen.choiceRec [
-        Lit <!> Gen.range 0 10
+        Lit <!> Gen.int (Range.constant 0 10)
         Var <!> genName
     ] [
         Lam <!> Gen.zip genName genExp


### PR DESCRIPTION
This pull request is part of a series of pull requests on bringing `Gen` in line with the Haskell version (#89).