### PR TITLE
Add doc/tutorial, make smaller README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+hedgehog [![Hackage][hackage-shield]][hackage] [![Travis][travis-shield]][travis]
+========
+
+> Hedgehog will eat all your bugs.
+
+<img src="https://github.com/hedgehogqa/haskell-hedgehog/raw/master/img/hedgehog-logo.png" width="307" align="right"/>
+
+[Hedgehog](http://hedgehog.qa/) is a modern property-based testing
+system, in the spirit of QuickCheck. Hedgehog uses integrated shrinking,
+so shrinks obey the invariants of generated values by construction.
+
+## Features
+
+- Integrated shrinking, shrinks obey invariants by construction.
+- Generators allow monadic effects.
+- Range combinators for full control over the scope of generated numbers and collections.
+- Equality and roundtrip assertions show a diff instead of the two inequal values.
+- Template Haskell test runner which executes properties concurrently.
+
+## Example
+
+The main module, [Hedgehog][haddock-hedgehog], includes almost
+everything you need to get started writing property tests with Hedgehog.
+
+It is designed to be used alongside [Hedgehog.Gen][haddock-hedgehog-gen]
+and [Hedgehog.Range][haddock-hedgehog-range] which should be imported
+qualified. You also need to enable Template Haskell so the Hedgehog test
+runner can find your properties.
+
+```hs
+{-# LANGUAGE TemplateHaskell #-}
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+```
+
+Once you have your imports set up, you can write a simple property:
+
+```hs
+prop_reverse :: Property
+prop_reverse =
+  property $ do
+    xs <- forAll $ Gen.list (Range.linear 0 100) Gen.alpha
+    reverse (reverse xs) === xs
+```
+
+And add the Template Haskell splice which will discover your properties:
+
+```hs
+tests :: IO Bool
+tests =
+  checkConcurrent $$(discover)
+```
+
+If you prefer to avoid macros, you can specify the group of properties
+to run manually instead:
+
+```hs
+tests :: IO Bool
+tests =
+  checkConcurrent $ Group "Test.Example" [
+      ("prop_reverse", prop_reverse)
+    ]
+```
+
+You can then load the module in GHCi, and run it:
+
+```
+λ tests
+━━━ Test.Example ━━━
+  ✓ prop_reverse passed 100 tests.
+
+```
+
+ [hackage]: http://hackage.haskell.org/package/hedgehog
+ [hackage-shield]: http://img.shields.io/hackage/v/hedgehog.svg?style=flat
+
+ [travis]: https://travis-ci.org/hedgehogqa/haskell-hedgehog
+ [travis-shield]: https://travis-ci.org/hedgehogqa/haskell-hedgehog.svg?branch=master
+
+ [haddock-hedgehog]: http://hackage.haskell.org/package/hedgehog/docs/Hedgehog.html
+ [haddock-hedgehog-gen]: http://hackage.haskell.org/package/hedgehog/docs/Hedgehog-Gen.html
+ [haddock-hedgehog-range]: http://hackage.haskell.org/package/hedgehog/docs/Hedgehog-Range.html

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-hedgehog [![Hackage][hackage-shield]][hackage] [![Travis][travis-shield]][travis]
+fsharp-hedgehog [![NuGet][nuget-shield]][nuget] [![Travis][travis-shield]][travis]
 ========
 
 > Hedgehog will eat all your bugs.
 
-<img src="https://github.com/hedgehogqa/haskell-hedgehog/raw/master/img/hedgehog-logo.png" width="307" align="right"/>
+<img src="https://github.com/hedgehogqa/fsharp-hedgehog/raw/master/img/SQUARE_hedgehog_615x615.png" width="307" align="right"/>
 
 [Hedgehog](http://hedgehog.qa/) is a modern property-based testing
 system, in the spirit of QuickCheck. Hedgehog uses integrated shrinking,
@@ -12,73 +12,38 @@ so shrinks obey the invariants of generated values by construction.
 ## Features
 
 - Integrated shrinking, shrinks obey invariants by construction.
-- Generators allow monadic effects.
+- Convenient syntax for generators and properties with `gen` and `property` expressions.
 - Range combinators for full control over the scope of generated numbers and collections.
-- Equality and roundtrip assertions show a diff instead of the two inequal values.
-- Template Haskell test runner which executes properties concurrently.
 
 ## Example
 
-The main module, [Hedgehog][haddock-hedgehog], includes almost
+The root namespace, `Hedgehog`, includes almost
 everything you need to get started writing property tests with Hedgehog.
 
-It is designed to be used alongside [Hedgehog.Gen][haddock-hedgehog-gen]
-and [Hedgehog.Range][haddock-hedgehog-range] which should be imported
-qualified. You also need to enable Template Haskell so the Hedgehog test
-runner can find your properties.
-
-```hs
-{-# LANGUAGE TemplateHaskell #-}
-
-import           Hedgehog
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
+```fs
+open Hedgehog
 ```
 
-Once you have your imports set up, you can write a simple property:
+Once you have your import declaration set up, you can write a simple property:
 
-```hs
-prop_reverse :: Property
-prop_reverse =
-  property $ do
-    xs <- forAll $ Gen.list (Range.linear 0 100) Gen.alpha
-    reverse (reverse xs) === xs
+```fs
+let propReverse : Property<Unit> =
+    property {
+        let! xs = Gen.list (Range.linear 0 100) Gen.alpha
+        return xs |> List.rev |> List.rev = xs
+        }
 ```
 
-And add the Template Haskell splice which will discover your properties:
-
-```hs
-tests :: IO Bool
-tests =
-  checkConcurrent $$(discover)
-```
-
-If you prefer to avoid macros, you can specify the group of properties
-to run manually instead:
-
-```hs
-tests :: IO Bool
-tests =
-  checkConcurrent $ Group "Test.Example" [
-      ("prop_reverse", prop_reverse)
-    ]
-```
-
-You can then load the module in GHCi, and run it:
+You can then load the module in F# Interactive, and run it:
 
 ```
-λ tests
-━━━ Test.Example ━━━
-  ✓ prop_reverse passed 100 tests.
+> Property.print propReverse
++++ OK, passed 100 tests.
 
 ```
 
- [hackage]: http://hackage.haskell.org/package/hedgehog
- [hackage-shield]: http://img.shields.io/hackage/v/hedgehog.svg?style=flat
+ [nuget]: https://www.nuget.org/packages/Hedgehog/
+ [nuget-shield]: https://img.shields.io/nuget/dt/Hedgehog.svg?style=flat
 
- [travis]: https://travis-ci.org/hedgehogqa/haskell-hedgehog
- [travis-shield]: https://travis-ci.org/hedgehogqa/haskell-hedgehog.svg?branch=master
-
- [haddock-hedgehog]: http://hackage.haskell.org/package/hedgehog/docs/Hedgehog.html
- [haddock-hedgehog-gen]: http://hackage.haskell.org/package/hedgehog/docs/Hedgehog-Gen.html
- [haddock-hedgehog-range]: http://hackage.haskell.org/package/hedgehog/docs/Hedgehog-Range.html
+ [travis]: https://travis-ci.org/hedgehogqa/fsharp-hedgehog
+ [travis-shield]: https://travis-ci.org/hedgehogqa/fsharp-hedgehog.svg?branch=master

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ You can then load the module in F# Interactive, and run it:
 
 ```
 
+More examples can be found in the [tutorial](doc/tutorial.md).
+
  [nuget]: https://www.nuget.org/packages/Hedgehog/
  [nuget-shield]: https://img.shields.io/nuget/dt/Hedgehog.svg?style=flat
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/hedgehogqa/fsharp-hedgehog.svg?branch=master)](https://travis-ci.org/hedgehogqa/fsharp-hedgehog)
-
 # fsharp-hedgehog
 
 An alternative property-based testing system for F#, in the spirit of John Hughes & Koen Classen's [QuickCheck](https://web.archive.org/web/20160319204559/http://www.cs.tufts.edu/~nr/cs257/archive/john-hughes/quick.pdf).


### PR DESCRIPTION
This resolves #69.

It basically

* adds a doc/tutorial.md which contains most of the stuff from the old README.md, updated to use the Range combinators
* ports README.md from Haskell version, with any features we don't currently support being removed for now

You can see a preview [here](https://github.com/moodmosaic/fsharp-hedgehog/blob/topic/readme/README.md).