### PR TITLE
Increment minor version

### DIFF
--- a/src/Hedgehog/AssemblyInfo.fs
+++ b/src/Hedgehog/AssemblyInfo.fs
@@ -12,7 +12,7 @@ open System.Runtime.CompilerServices
 
 // The assembly version has the format {Major}.{Minor}.{Build}
 
-[<assembly: AssemblyVersion("0.1.0")>]
+[<assembly: AssemblyVersion("0.2.0")>]
 
 //[<assembly: AssemblyDelaySign(false)>]
 //[<assembly: AssemblyKeyFile("")>]


### PR DESCRIPTION
so we can push it on NuGet as Hedgehog 0.2.0.

In version 0.2.0, `Gen` combinators have been modified so they can take a `Range` type, and they are now closer to the Haskell version of Hedgehog.
