### PR TITLE
Exclude FSharp.Core NuGet dependency

### DIFF
--- a/src/Hedgehog/paket.template
+++ b/src/Hedgehog/paket.template
@@ -18,3 +18,5 @@ iconUrl
     https://github.com/hedgehogqa/fsharp-hedgehog/raw/master/img/SQUARE_hedgehog_300x300.png
 tags
     fsharp, f#, testing
+excludeddependencies
+    FSharp.Core


### PR DESCRIPTION
This is per the official F# guidelines at
https://fsharp.github.io/2015/04/18/fsharp-core-notes.html#do-not-bundle-fsharpcore-with-a-library,
the gist of which is:

> Do not include a copy of FSharp.Core with your library or package. If
> you do, you will create havoc for users of your library.
>
> The decision about which FSharp.Core a library binds to is up to the
> application hosting of the library. The library and/or library package
> can place constraints on this, but it doesn’t decide it.