### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+## Version 0.3 (2017-07-24)
+
+- Add Range exponential combinators ([#105][105], [@moodmosaic][moodmosaic])
+- Change Gen.double and Gen.float so that they take a Range type ([#104][104], [@moodmosaic][moodmosaic])
+- Shrink floating binary point types similar to the Haskell version ([#103][103], [@moodmosaic][moodmosaic])
+- Add F# interactive examples to the Shrink module ([#102][102], [@moodmosaic][moodmosaic])
+- Test F# interactive examples with Doctest ([#99][99], [@moodmosaic][moodmosaic])
+
+## Version 0.2.1 (2017-05-16)
+
+- Add ASCII, Latin-1, and Unicode character generators ([#96][96], [@moodmosaic][moodmosaic])
+
+## Version 0.2.0 (2017-05-06)
+
+- Add doc/tutorial, make smaller README ([#94][94], [@moodmosaic][moodmosaic])
+- Modify Gen combinators so that they take a Range ([#92][92], [@moodmosaic][moodmosaic])
+- Add Range type and combinators ([#91][91], [@moodmosaic][moodmosaic])
+- Improve the Visual Studio dev experience ([#90][90], [@porges][porges])
+
+## Version 0.1 (2017-05-06)
+
+- First release of Hedgehog ([@jystic][jystic], [@moodmosaic][moodmosaic])
+
+[jystic]:
+  https://github.com/jystic
+[moodmosaic]:
+  https://github.com/moodmosaic
+[porges]:
+  https://github.com/porges
+
+[105]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/105
+[104]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/104
+[103]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/103
+[102]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/102
+[99]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/99
+[96]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/96
+[94]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/94
+[92]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/92
+[91]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/91
+[90]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/90


### PR DESCRIPTION
This is similar to https://github.com/hedgehogqa/haskell-hedgehog/pull/71/. I've noticed that Microsoft updated the NuGet Gallery UI and so the idea here is that we can show a changelog in [Hedgehog NuGet page](https://www.nuget.org/packages/Hedgehog/).