### PR TITLE
IDE-readable API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,6 @@ Thumbs.db
 # Hedgehog NuGet Package output directory
 .nuget
 
-# Doctest - Test interactive F# examples, similar to doctest for Haskell
-Doctest
-
 # FAKE - F# Make
 .fake/
 

--- a/build.fsx
+++ b/build.fsx
@@ -8,31 +8,6 @@ Target "Build" <| fun _ ->
     |> MSBuildRelease "" "Rebuild"
     |> ignore
 
-Target "Doctest" (fun _ ->
-    CreateDir "Doctest"
-    CopyFiles "Doctest" [
-        "packages/testing/Argu/lib/net40/Argu.dll"
-        "packages/testing/FSharp.Compiler.Service/lib/net45/FSharp.Compiler.Service.dll"
-        "packages/testing/FSharp.Core/lib/net45/FSharp.Core.dll"
-        "packages/testing/FSharp.Data/lib/net40/FSharp.Data.dll"
-        "packages/testing/Unquote/lib/net40/Unquote.dll"
-        "packages/testing/Doctest/lib/net452/Doctest.exe"
-        "packages/testing/Doctest/lib/net452/Doctest.exe.config"
-        ]
-    let cmd =
-        "Doctest/Doctest.exe"
-    let arg =
-        System.IO.Path.Combine
-            (__SOURCE_DIRECTORY__, "src/Hedgehog/bin/Release/Hedgehog.dll")
-
-    let exitCode =
-        Shell.Exec (cmd, arg)
-
-    if  exitCode = 0 then
-        ()
-    else
-        failwithf "The command %s %s exited with code %i" cmd arg exitCode)
-
 Target "Test" (fun _ ->
     !! "**/bin/Release/*Hedgehog.*Tests.dll"
     |> xUnit2 (fun p -> { p with Parallel = ParallelMode.All }))
@@ -41,7 +16,6 @@ Target "NuGet" (fun _ ->
     Paket.Pack (fun p -> { p with OutputPath = ".nuget" }))
 
 "Build"
-==> "Doctest"
 ==> "Test"
 ==> "NuGet"
 

--- a/src/Hedgehog/Range.fs
+++ b/src/Hedgehog/Range.fs
@@ -2,9 +2,6 @@
 
 open Hedgehog.Numeric
 
-/// $setup
-/// >>> let x = 3
-
 /// Tests are parameterized by the `Size` of the randomly-generated data,
 /// the meaning of which depends on the particular generator used.
 type Size = int
@@ -58,62 +55,20 @@ module Range =
     //
 
     /// Construct a range which represents a constant single value.
-    ///
-    /// >>> Range.bounds x <| Range.singleton 5
-    /// (5, 5)
-    ///
-    /// >>> Range.origin <| Range.singleton 5
-    /// 5
-    ///
     let singleton (x : 'a) : Range<'a> =
         Range (x, fun _ -> x, x)
 
     /// Construct a range which is unaffected by the size parameter with a
     /// origin point which may differ from the bounds.
-    ///
-    /// A range from @-10@ to @10@, with the origin at @0@:
-    ///
-    /// >>> Range.bounds x <| Range.constantFrom 0 (-10) 10
-    /// (-10, 10)
-    ///
-    /// >>> Range.origin <| Range.constantFrom 0 (-10) 10
-    /// 0
-    ///
-    /// A range from @1970@ to @2100@, with the origin at @2000@:
-    ///
-    /// >>> Range.bounds x <| Range.constantFrom 2000 1970 2100
-    /// (1970, 2100)
-    ///
-    /// >>> Range.origin <| Range.constantFrom 2000 1970 2100
-    /// 2000
-    ///
     let constantFrom (z : 'a) (x : 'a) (y : 'a) : Range<'a> =
         Range (z, fun _ -> x, y)
 
     /// Construct a range which is unaffected by the size parameter.
-    ///
-    /// A range from @0@ to @10@, with the origin at @0@:
-    ///
-    /// >>> Range.bounds x <| Range.constant 0 10
-    /// (0, 10)
-    ///
-    /// >>> Range.origin <| Range.constant 0 10
-    /// 0
-    ///
     let constant (x : 'a) : ('a -> Range<'a>) =
         constantFrom x x
 
     /// Construct a range which is unaffected by the size parameter using the
     /// full range of a data type.
-    ///
-    /// A range from @-128@ to @127@, with the origin at @0@:
-    ///
-    /// >>> Range.bounds x (Range.constantBounded () : Range<sbyte>)
-    /// (-128y, 127y)
-    ///
-    /// >>> Range.origin <| (Range.constantBounded () : Range<sbyte>)
-    /// 0y
-    ///
     let inline constantBounded () : Range<'a> =
         let lo = minValue ()
         let hi = maxValue ()
@@ -135,13 +90,6 @@ module Range =
         // sufficiently accessible.
 
         /// Truncate a value so it stays within some range.
-        ///
-        /// >>> Range.Internal.clamp 5 10 15
-        /// 10
-        ///
-        /// >>> Range.Internal.clamp 5 10 0
-        /// 5
-        ///
         let clamp (x : 'a) (y : 'a) (n : 'a) : 'a =
             if x > y then
                 min x (max y n)
@@ -182,16 +130,6 @@ module Range =
 
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
-    ///
-    /// >>> Range.bounds 0 <| Range.linearFrom 0 (-10) 10
-    /// (0, 0)
-    ///
-    /// >>> Range.bounds 50 <| Range.linearFrom 0 (-10) 20
-    /// (-5, 10)
-    ///
-    /// >>> Range.bounds 99 <| Range.linearFrom 0 (-10) 20
-    /// (-10, 20)
-    ///
     let inline linearFrom (z : 'a) (x : 'a) (y : 'a) : Range<'a> =
         Range (z, fun sz ->
             let x_sized =
@@ -202,31 +140,11 @@ module Range =
 
     /// Construct a range which scales the second bound relative to the size
     /// parameter.
-    ///
-    /// >>> Range.bounds 0 <| Range.linear 0 10
-    /// (0, 0)
-    ///
-    /// >>> Range.bounds 50 <| Range.linear 0 10
-    /// (0, 5)
-    ///
-    /// >>> Range.bounds 99 <| Range.linear 0 10
-    /// (0, 10)
-    ///
     let inline linear (x : 'a) : ('a -> Range<'a>) =
       linearFrom x x
 
     /// Construct a range which is scaled relative to the size parameter and
     /// uses the full range of a data type.
-    ///
-    /// >>> Range.bounds 0 (Range.linearBounded () : Range<sbyte>)
-    /// (-0y, 0y)
-    ///
-    /// >>> Range.bounds 50 (Range.linearBounded () : Range<sbyte>)
-    /// (-64y, 64y)
-    ///
-    /// >>> Range.bounds 99 (Range.linearBounded () : Range<sbyte>)
-    /// (-128y, 127y)
-    ///
     let inline linearBounded () : Range<'a> =
         let lo = minValue ()
         let hi = maxValue ()
@@ -240,22 +158,6 @@ module Range =
 
     /// Construct a range which scales the bounds exponentially relative to the
     /// size parameter.
-    ///
-    /// >>> Range.bounds 0 (Range.exponentialFrom 0 -128 512)
-    /// (0, 0)
-    ///
-    /// >>> Range.bounds 25 (Range.exponentialFrom 0 -128 512)
-    /// (-2, 4)
-    ///
-    /// >>> Range.bounds 50 (Range.exponentialFrom 0 -128 512)
-    /// (-11, 22)
-    ///
-    /// >>> Range.bounds 75 (Range.exponentialFrom 0 -128 512)
-    /// (-39, 112)
-    ///
-    /// >>> Range.bounds 99 (Range.exponentialFrom x -128 512)
-    /// (-128, 512)
-    ///
     let inline exponentialFrom (z : 'a) (x : 'a) (y : 'a) : Range<'a> =
         Range (z, fun sz ->
             let x_sized =
@@ -266,40 +168,11 @@ module Range =
 
     /// Construct a range which scales the second bound exponentially relative
     /// to the size parameter.
-    ///
-    /// >>> Range.bounds 0 (Range.exponential 1 512)
-    /// (1, 1)
-    ///
-    /// >>> Range.bounds 11 (Range.exponential 1 512)
-    /// (1, 2)
-    ///
-    /// >>> Range.bounds 22 (Range.exponential 1 512)
-    /// (1, 4)
-    ///
-    /// >>> Range.bounds 77 (Range.exponential 1 512)
-    /// (1, 128)
-    ///
-    /// >>> Range.bounds 88 (Range.exponential 1 512)
-    /// (1, 256)
-    ///
-    /// >>> Range.bounds 99 (Range.exponential 1 512)
-    /// (1, 512)
-    ///
     let inline exponential (x : 'a) (y : 'a) : Range<'a> =
         exponentialFrom x x y
 
     /// Construct a range which is scaled exponentially relative to the size
     /// parameter and uses the full range of a data type.
-    ///
-    /// >>> Range.bounds 0 (Range.exponentialBounded () : Range<sbyte>)
-    /// (0y, 0y)
-    ///
-    /// >>> Range.bounds 50 (Range.exponentialBounded () : Range<sbyte>)
-    /// (-11y, 11y)
-    ///
-    /// >>> Range.bounds 99 (Range.exponentialBounded () : Range<sbyte>)
-    /// (-128y, 127y)
-    ///
     let inline exponentialBounded () : Range<'a> =
         let lo = minValue ()
         let hi = maxValue ()

--- a/src/Hedgehog/Shrink.fs
+++ b/src/Hedgehog/Shrink.fs
@@ -20,21 +20,8 @@ module LazyList =
             else
                 LazyList.cons x <| LazyList.cons y ys
 
-/// $setup
-/// >>> open FSharpx.Collections
-
 module Shrink =
     /// Produce all permutations of removing 'k' elements from a list.
-    ///
-    /// >>> LazyList.toList <| Shrink.removes 2 [1; 2; 3; 4; 5; 6]
-    /// [[3; 4; 5; 6]; [1; 2; 5; 6]; [1; 2; 3; 4]]
-    ///
-    /// >>> LazyList.toList <| Shrink.removes 3 [1; 2; 3; 4; 5; 6]
-    /// [[4; 5; 6]; [1; 2; 3]]
-    ///
-    /// >>> LazyList.toList <| Shrink.removes 2 ["a"; "b"; "c"; "d"; "e"; "f"]
-    /// [["c"; "d"; "e"; "f"]; ["a"; "b"; "e"; "f"]; ["a"; "b"; "c"; "d"]]
-    ///
     let removes (k0 : int) (xs0 : List<'a>) : LazyList<List<'a>> =
         let rec loop (k : int) (n : int) (xs : List<'a>) : LazyList<List<'a>> =
             let hd = List.take k xs
@@ -49,16 +36,6 @@ module Shrink =
         loop k0 (List.length xs0) xs0
 
     /// Produce a list containing the progressive halving of an integral.
-    ///
-    /// >>> LazyList.toList <| Shrink.halves 15
-    /// [15; 7; 3; 1]
-    ///
-    /// >>> LazyList.toList <| Shrink.halves 100
-    /// [100; 50; 25; 12; 6; 3; 1]
-    ///
-    /// >>> LazyList.toList <| Shrink.halves -26
-    /// [-26; -13; -6; -3; -1]
-    ///
     let inline halves (n : ^a) : LazyList<'a> =
         let go x =
             let zero : ^a = LanguagePrimitives.GenericZero
@@ -72,15 +49,7 @@ module Shrink =
         LazyList.unfold go n
 
     /// Shrink a list by edging towards the empty list.
-    ///
-    /// >>> LazyList.toList <| Shrink.list [1; 2; 3]
-    /// [[]; [2; 3]; [1; 3]; [1; 2]]
-    ///
-    /// >>> LazyList.toList <| Shrink.list ["a"; "b"; "c"; "d"]
-    /// [[]; ["c"; "d"]; ["a"; "b"]; ["b"; "c"; "d"]; ["a"; "c"; "d"]; ["a"; "b"; "d"]; ["a"; "b"; "c"]]
-    ///
     /// Note we always try the empty list first, as that is the optimal shrink.
-    ///
     let list (xs : List<'a>) : LazyList<List<'a>> =
         LazyList.concatMap (fun k -> removes k xs) (halves <| List.length xs)
 
@@ -115,16 +84,6 @@ module Shrink =
             elems Tree.shrinks xs) xs0
 
     /// Shrink an integral number by edging towards a destination.
-    ///
-    /// >>> LazyList.toList <| Shrink.towards 0 100
-    /// [0; 50; 75; 88; 94; 97; 99]
-    ///
-    /// >>> LazyList.toList <| Shrink.towards 500 1000
-    /// [500; 750; 875; 938; 969; 985; 993; 997; 999]
-    ///
-    /// >>> LazyList.toList <| Shrink.towards -50 -26
-    /// [-50; -38; -32; -29; -27]
-    ///
     let inline towards (destination : ^a) (x : ^a) : LazyList<'a> =
         if destination = x then
             LazyList.empty
@@ -140,15 +99,7 @@ module Shrink =
             LazyList.map (fun y -> x - y) (halves diff)
 
     /// Shrink a floating-point number by edging towards a destination.
-    ///
-    /// >>> List.take 7 << LazyList.toList <| Shrink.towardsDouble 0.0 100.0
-    /// [0.0; 50.0; 75.0; 87.5; 93.75; 96.875; 98.4375]
-    ///
-    /// >>> List.take 7 << LazyList.toList <| Shrink.towardsDouble 1.0 0.5
-    /// [1.0; 0.75; 0.625; 0.5625; 0.53125; 0.515625; 0.5078125]
-    ///
     /// Note we always try the destination first, as that is the optimal shrink.
-    ///
     let towardsDouble (destination : double) (x : double) : LazyList<double> =
         if destination = x then
             LazyList.empty

--- a/src/Hedgehog/Tree.fs
+++ b/src/Hedgehog/Tree.fs
@@ -67,7 +67,7 @@ module Tree =
     ///
     /// If you want to replace the shrinks altogether, try:
     ///
-    /// <c>Tree.unfold f (outcome oldTree)</c>
+    /// Tree.unfold f (outcome oldTree)
     ///
     let rec expand (f : 'a -> LazyList<'a>) (Node (x, xs) : Tree<'a>) : Tree<'a> =
         //
@@ -82,7 +82,7 @@ module Tree =
         Node (x, LazyList.append ys zs)
 
     /// Recursively discard any shrinks whose outcome does not pass the predicate.
-    /// <i>Note that the root outcome can never be discarded</i>
+    /// Note that the root outcome can never be discarded.
     let rec filter (f : 'a -> bool) (Node (x, xs) : Tree<'a>) : Tree<'a> =
         Node (x, filterForest f xs)
 

--- a/tests/Hedgehog.Tests/RangeTests.fs
+++ b/tests/Hedgehog.Tests/RangeTests.fs
@@ -136,6 +136,15 @@ let ``constantBounded bounds returns correct result - Int64 range`` sz =
     (Int64.MinValue, Int64.MaxValue) =!
         x
 
+[<Theory>]
+[<InlineData(5, 10, 15, 10)>]
+[<InlineData(5, 10,  0,  5)>]
+let ``clamp truncates a value so it stays within some range `` x y n expected =
+    let actual =
+        Range.Internal.clamp x y n
+    expected =!
+        actual
+
 [<Fact>]
 let ``linear scales the second bound relative to the size - example 1`` () =
     let actual =

--- a/tests/Hedgehog.Tests/ShrinkTests.fs
+++ b/tests/Hedgehog.Tests/ShrinkTests.fs
@@ -16,6 +16,91 @@ let ``removes permutes a list by removing 'k' consecutive elements from it``() =
     // http://stackoverflow.com/a/17101488
     test <@ Seq.fold (&&) true (Seq.zip expected actual |> Seq.map (fun (a, b) -> a = b)) @>
 
+[<Fact>]
+let ``removes produces all permutations of removing 'k' elements from a list - example 1`` () =
+    let actual =
+        LazyList.toList <| Shrink.removes 2 [1; 2; 3; 4; 5; 6]
+    [[3; 4; 5; 6]; [1; 2; 5; 6]; [1; 2; 3; 4]] =! actual
+
+[<Fact>]
+let ``removes produces all permutations of removing 'k' elements from a list - example 2`` () =
+    let actual =
+        LazyList.toList <| Shrink.removes 3 [1; 2; 3; 4; 5; 6]
+    [[4; 5; 6]; [1; 2; 3]] =! actual
+
+[<Fact>]
+let ``removes produces all permutations of removing 'k' elements from a list - example 3`` () =
+    let actual =
+        LazyList.toList <| Shrink.removes 2 ["a"; "b"; "c"; "d"; "e"; "f"]
+    [["c"; "d"; "e"; "f"]; ["a"; "b"; "e"; "f"]; ["a"; "b"; "c"; "d"]] =! actual
+
+[<Fact>]
+let ``halves produces a list containing the progressive halving of an integral - example 1`` () =
+    let actual =
+        LazyList.toList <| Shrink.halves 15
+    [15; 7; 3; 1] =! actual
+
+[<Fact>]
+let ``halves produces a list containing the progressive halving of an integral - example 2`` () =
+    let actual =
+        LazyList.toList <| Shrink.halves 100
+    [100; 50; 25; 12; 6; 3; 1] =! actual
+
+[<Fact>]
+let ``halves produces a list containing the progressive halving of an integral - example 3`` () =
+    let actual =
+        LazyList.toList <| Shrink.halves -26
+    [-26; -13; -6; -3; -1] =! actual
+
+[<Fact>]
+let ``list shrinks a list by edging towards the empty list - example 1`` () =
+    let actual =
+        LazyList.toList <| Shrink.list [1; 2; 3]
+    [[]; [2; 3]; [1; 3]; [1; 2]] =! actual
+
+[<Fact>]
+let ``list shrinks a list by edging towards the empty list - example 2`` () =
+    let actual =
+        LazyList.toList <| Shrink.list ["a"; "b"; "c"; "d"]
+    [ []
+      [ "c"; "d" ]
+      [ "a"; "b" ]
+      [ "b"; "c"; "d" ]
+      [ "a"; "c"; "d" ]
+      [ "a"; "b"; "d" ]
+      [ "a"; "b"; "c" ] ]
+    =! actual
+
+[<Fact>]
+let ``towards shrinks an integral number by edging towards a destination - exmaple 1`` () =
+    let actual =
+        LazyList.toList <| Shrink.towards 0 100
+    [0; 50; 75; 88; 94; 97; 99] =! actual
+
+[<Fact>]
+let ``towards shrinks an integral number by edging towards a destination - exmaple 2`` () =
+    let actual =
+        LazyList.toList <| Shrink.towards 500 1000
+    [500; 750; 875; 938; 969; 985; 993; 997; 999] =! actual
+
+[<Fact>]
+let ``towards shrinks an integral number by edging towards a destination - exmaple 3`` () =
+    let actual =
+        LazyList.toList <| Shrink.towards -50 -26
+    [-50; -38; -32; -29; -27] =! actual
+
+[<Fact>]
+let ``towardsDouble shrinks a floating-point number by edging towards a destination - example 1`` () =
+    let actual =
+        List.take 7 << LazyList.toList <| Shrink.towardsDouble 0.0 100.0
+    [0.0; 50.0; 75.0; 87.5; 93.75; 96.875; 98.4375] =! actual
+
+[<Fact>]
+let ``towardsDouble shrinks a floating-point number by edging towards a destination - example 2`` () =
+    let actual =
+        List.take 7 << LazyList.toList <| Shrink.towardsDouble 1.0 0.5
+    [1.0; 0.75; 0.625; 0.5625; 0.53125; 0.515625; 0.5078125] =! actual
+
 [<Theory>]
 [<InlineData(-4096)>]
 [<InlineData(-2048)>]


### PR DESCRIPTION
Addresses #117 by removing `doctests` in favor of F# Formatting (#118). Any `doctests` that don't exist already as example-based tests are added in to the *Hedgehog.Tests* project.

The XML documentation shouldn't be hard to read now on Visual Studio and other tools supporting F#:

![image](https://user-images.githubusercontent.com/287532/31332986-268ec5e4-acf1-11e7-85b4-ef599599d32f.png)

/cc @jystic @ploeh 