### PR TITLE
Release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.4.3 (2017-10-12)
+
+- Add ToBigInt overload for System.Double ([#136][136], [@moodmosaic][moodmosaic])
+
 ## Version 0.4.2 (2017-10-10)
 
 - Increase size in Discard case ([#129][129], [@moodmosaic][moodmosaic])
@@ -46,6 +50,8 @@
 [porges]:
   https://github.com/porges
 
+[136]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/136
 [129]:
   https://github.com/hedgehogqa/fsharp-hedgehog/pull/129
 [122]:

--- a/src/Hedgehog/AssemblyInfo.fs
+++ b/src/Hedgehog/AssemblyInfo.fs
@@ -12,7 +12,7 @@ open System.Runtime.CompilerServices
 
 // The assembly version has the format {Major}.{Minor}.{Build}
 
-[<assembly: AssemblyVersion("0.4.2")>]
+[<assembly: AssemblyVersion("0.4.3")>]
 
 //[<assembly: AssemblyDelaySign(false)>]
 //[<assembly: AssemblyKeyFile("")>]


### PR DESCRIPTION
- Add ToBigInt overload for System.Double (#136)