### PR TITLE
Make Journal store delayed strings, so they are computed on-demand

### DIFF
--- a/src/Hedgehog/Script.fsx
+++ b/src/Hedgehog/Script.fsx
@@ -102,7 +102,7 @@ Property.print <| property {
         // Custom operations (i.e. counterexample) can't be used in computation
         // expressions which have control flow :( we can fake it using return!
         // however.
-        return! Property.counterexample (sprintf "x = %A" x)
+        return! Property.counterexample (fun () -> sprintf "x = %A" x)
 
         // Note, return can be used multiple times, its a bit like 'assert'.
         return x <> 'w'
@@ -112,8 +112,8 @@ Property.print <| property {
     while n < 10 do
         n <- n + 1
         let! k = Gen.int <| Range.constant 0 n
-        return! Property.counterexample (sprintf "n = %d" n)
-        return! Property.counterexample (sprintf "k = %d" k)
+        return! Property.counterexample (fun () -> sprintf "n = %d" n)
+        return! Property.counterexample (fun () -> sprintf "k = %d" k)
         return k <> 5
 }
 

--- a/tests/Hedgehog.Tests/MinimalTests.fs
+++ b/tests/Hedgehog.Tests/MinimalTests.fs
@@ -62,10 +62,6 @@ let rec genExp : Gen<Exp> =
         App <!> Gen.zip genExp genExp
     ]
 
-// FIXME This test takes quite some time to run, it would be good to profile
-// FIXME this and find out where the hotspots are. I have a much more complex
-// FIXME version of the same test in Haskell and it finishes in a few seconds,
-// FIXME even in GHCi (the interpreter).
 [<Fact>]
 let ``greedy traversal with a predicate yields the perfect minimal shrink``() =
     Property.check <| property {


### PR DESCRIPTION
This fixes the performance issues in the "greedy traversal" test (#146).

I'm not entirely sure about the change to `PropertyBuilder.CounterExample`, but it's not really user-visible (they would be using the `counterexample` 'action' instead of calling this directly).

There's another `string` call which is _not_ delayed (line 275) as it didn't seem to be a performance issue.