### PR TITLE
Version 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Version 0.4.4 (2017-10-31)
+## Version 0.6.0 (2017-11-07)
+
+- Make Journal store delayed strings, so they are computed on-demand ([#147][147], [@porges][porges])
+
+## Version 0.5.0 (2017-11-06)
 
 - Support for LINQ queries ([#113][113], [@porges][porges])
 
@@ -58,6 +62,8 @@
 [porges]:
   https://github.com/porges
 
+[147]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/147
 [142]:
   https://github.com/hedgehogqa/fsharp-hedgehog/pull/142
 [136]:

--- a/src/Hedgehog/AssemblyInfo.fs
+++ b/src/Hedgehog/AssemblyInfo.fs
@@ -12,7 +12,7 @@ open System.Runtime.CompilerServices
 
 // The assembly version has the format {Major}.{Minor}.{Build}
 
-[<assembly: AssemblyVersion("0.5.0")>]
+[<assembly: AssemblyVersion("0.6.0")>]
 
 //[<assembly: AssemblyDelaySign(false)>]
 //[<assembly: AssemblyKeyFile("")>]


### PR DESCRIPTION
- Make Journal store delayed strings, so they are computed on-demand (#147)