### PR TITLE
fix for returning noncharacters from Gen.unicode

### DIFF
--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -393,11 +393,17 @@ module Gen =
     let latin1 : Gen<char> =
         char '\000' '\255'
 
-    /// Generates a Unicode character, excluding invalid standalone surrogates:
-    /// '\000'..'\65535' (excluding '\55296'..'\57343')
+    /// Generates a Unicode character, excluding noncharacters
+    /// ('\65534', '\65535') and invalid standalone surrogates
+    /// ('\000'..'\65535' excluding '\55296'..'\57343').
     [<CompiledName("Unicode")>]
     let unicode : Gen<char> =
-        filter (not << System.Char.IsSurrogate) unicodeAll
+        let isNoncharacter x = 
+               x = Operators.char 65534
+            || x = Operators.char 65535
+        unicodeAll
+        |> filter (not << isNoncharacter)
+        |> filter (not << System.Char.IsSurrogate)
 
     // Generates a random alpha character.
     [<CompiledName("Alpha")>]

--- a/tests/Hedgehog.Tests/GenTests.fs
+++ b/tests/Hedgehog.Tests/GenTests.fs
@@ -18,3 +18,16 @@ let ``dateTime creates System.DateTime instances`` count =
     |> List.distinct
     |> List.length
     =! actual.Length
+
+[<Fact>]
+let ``unicode doesn't return any surrogate`` () =
+    let actual = Gen.sample 100 100000 Gen.unicode 
+    [] =! List.filter System.Char.IsSurrogate actual
+
+[<Theory>]
+[<InlineData(65534)>]
+[<InlineData(65535)>]
+let ``unicode doesn't return any noncharacter`` nonchar =
+    let isNoncharacter = (=) <| Operators.char nonchar
+    let actual = Gen.sample 100 100000 Gen.unicode
+    [] =! List.filter isNoncharacter actual


### PR DESCRIPTION
I solved the issue #158.

closes #158 