### PR TITLE
fix for generating out-of-range values,

### DIFF
--- a/src/Hedgehog/Numeric.fs
+++ b/src/Hedgehog/Numeric.fs
@@ -199,10 +199,10 @@ type FromBigInt =
         fun (x : bigint) -> uint16 (int x)
 
     static member FromBigInt (_ : uint32, _ : FromBigInt) =
-        fun (x : bigint) -> uint32 (int x)
+        fun (x : bigint) -> uint32 x
 
     static member FromBigInt (_ : uint64, _ : FromBigInt) =
-        fun (x : bigint) -> uint64 (int64 x)
+        fun (x : bigint) -> uint64 x
 
     static member FromBigInt (_ : float32, _ : FromBigInt) =
         fun (x : bigint) -> float32 (int x)
@@ -246,10 +246,10 @@ type ToBigInt =
         x
 
     static member ToBigInt (x : uint32) =
-        bigint (int x)
+        bigint x
 
     static member ToBigInt (x : uint64) =
-        bigint (int64 x)
+        bigint x
 
     static member ToBigInt (x : double) =
         bigint x

--- a/tests/Hedgehog.Tests/GenTests.fs
+++ b/tests/Hedgehog.Tests/GenTests.fs
@@ -1,5 +1,6 @@
 ﻿module Hedgehog.Tests.GenTests
 
+open System
 open Hedgehog
 open Swensen.Unquote
 open Xunit
@@ -63,3 +64,15 @@ let ``dateTime shrinks to correct mid-value`` () =
         |> Array.item 1
         |> System.DateTime.Parse
     System.DateTime (2000, 1, 1) =! result
+
+[<Fact>]
+let ``uint64 doesn't return any out-of-range value`` () =
+    let gen = Gen.uint64 <| Range.constant 1UL UInt64.MaxValue
+    let actual = Gen.sample 0 100 gen
+    test <@ actual |> List.contains 0UL |> not @>
+
+[<Fact>]
+let ``uint32 doesn't return any out-of-range value`` () =
+    let gen = Gen.uint32 <| Range.constant 1ul UInt32.MaxValue
+    let actual = Gen.sample 0 100 gen
+    test <@ actual |> List.contains 0ul |> not @>


### PR DESCRIPTION
This commit addresses that generating uint32 and uint64 returns
out-of-range values. This problem occurs in numeric conversions.