### PR TITLE
introduce the Gen static class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ paket-files
 
 # Visual Studio files
 .vs/
+
+# Rider IDE
+.idea/

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -32,7 +32,6 @@ module Gen =
     let create (shrink : 'a -> LazyList<'a>) (random : Random<'a>) : Gen<'a> =
         Random.map (Tree.unfold id shrink) random |> ofRandom
 
-    [<CompiledName("Constant")>]
     let constant (x : 'a) : Gen<'a> =
         Tree.singleton x |> Random.constant |> ofRandom
 
@@ -64,7 +63,6 @@ module Gen =
     let mapTree (f : Tree<'a> -> Tree<'b>) (g : Gen<'a>) : Gen<'b> =
         mapRandom (Random.map f) g
 
-    [<CompiledName("Map")>]
     let map (f : 'a -> 'b) (g : Gen<'a>) : Gen<'b> =
         mapTree (Tree.map f) g
 
@@ -550,7 +548,12 @@ module GenOperators =
     let (<!>) = Gen.map
     let (<*>) = Gen.apply
 
+open System
+
 /// In C# friendly manner, a generator for values and shrink trees of type 'a
 type Gen =
     static member Bool = Gen.bool
     static member Int32(range : Range<int>) : Gen<int> = Gen.int range
+    static member Constant(x : 'a) : Gen<'a> = Gen.constant x
+    static member Map(f : Func<'a, 'b>) (g : Gen<'a>) : Gen<'b> =
+        Gen.map f.Invoke g

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -398,7 +398,7 @@ module Gen =
     /// ('\000'..'\65535' excluding '\55296'..'\57343').
     [<CompiledName("Unicode")>]
     let unicode : Gen<char> =
-        let isNoncharacter x = 
+        let isNoncharacter x =
                x = Operators.char 65534
             || x = Operators.char 65535
         unicodeAll
@@ -428,7 +428,6 @@ module Gen =
     //
 
     /// Generates a random boolean.
-    [<CompiledName("Bool")>]
     let bool : Gen<bool> =
         item [false; true]
 
@@ -453,7 +452,6 @@ module Gen =
         integral range
 
     /// Generates a random signed 32-bit integer.
-    [<CompiledName("Int32")>]
     let int (range : Range<int>) : Gen<int> =
         integral range
 
@@ -551,3 +549,8 @@ module GenBuilder =
 module GenOperators =
     let (<!>) = Gen.map
     let (<*>) = Gen.apply
+
+/// In C# friendly manner, a generator for values and shrink trees of type 'a
+type Gen =
+    static member Bool = Gen.bool
+    static member Int32(range : Range<int>) : Gen<int> = Gen.int range

--- a/tests/Hedgehog.CSharp.Tests/GenTests.cs
+++ b/tests/Hedgehog.CSharp.Tests/GenTests.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+using static Hedgehog.Property;
+
+namespace Hedgehog.CSharp.Tests
+{
+    public class GenTests
+    {
+        [Fact]
+        public void CanUseMapInCSharpFriendlyManner()
+        {
+            Gen<int> gen =
+                Gen.Map(x => x + 1, Gen.Constant(1));
+            Check(
+                from x in ForAll(gen)
+                select Assert.Equal(2, x));
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses #172. To expose C# friendly members, the Gen static class is introduced. This causes renaming the gen module from 'Gen' to 'GenModule'. We can use the new Gen static class in C# without F# type disturbance. One big drawback is that we should re-declare all the gen members.

In a short, frequent and repetitive way, I has re-declared only some members. 

/cc @Porges 