### PR TITLE
Proposed fix for issue #185

### DIFF
--- a/src/Hedgehog/Numeric.fs
+++ b/src/Hedgehog/Numeric.fs
@@ -199,10 +199,10 @@ type FromBigInt =
         fun (x : bigint) -> uint16 (int x)
 
     static member FromBigInt (_ : uint32, _ : FromBigInt) =
-        fun (x : bigint) -> uint32 (int x)
+        fun (x : bigint) -> uint32 x
 
     static member FromBigInt (_ : uint64, _ : FromBigInt) =
-        fun (x : bigint) -> uint64 (int64 x)
+        fun (x : bigint) -> uint64 x
 
     static member FromBigInt (_ : float32, _ : FromBigInt) =
         fun (x : bigint) -> float32 (int x)
@@ -246,10 +246,10 @@ type ToBigInt =
         x
 
     static member ToBigInt (x : uint32) =
-        bigint (int x)
+        bigint x
 
     static member ToBigInt (x : uint64) =
-        bigint (int64 x)
+        bigint x
 
     static member ToBigInt (x : double) =
         bigint x

--- a/src/Hedgehog/Numeric.fs
+++ b/src/Hedgehog/Numeric.fs
@@ -199,10 +199,10 @@ type FromBigInt =
         fun (x : bigint) -> uint16 (int x)
 
     static member FromBigInt (_ : uint32, _ : FromBigInt) =
-        fun (x : bigint) -> uint32 x
+        fun (x : bigint) -> uint32 (int x)
 
     static member FromBigInt (_ : uint64, _ : FromBigInt) =
-        fun (x : bigint) -> uint64 x
+        fun (x : bigint) -> uint64 (int64 x)
 
     static member FromBigInt (_ : float32, _ : FromBigInt) =
         fun (x : bigint) -> float32 (int x)
@@ -246,10 +246,10 @@ type ToBigInt =
         x
 
     static member ToBigInt (x : uint32) =
-        bigint x
+        bigint (int x)
 
     static member ToBigInt (x : uint64) =
-        bigint x
+        bigint (int64 x)
 
     static member ToBigInt (x : double) =
         bigint x

--- a/src/Hedgehog/Range.fs
+++ b/src/Hedgehog/Range.fs
@@ -135,9 +135,8 @@ module Range =
             let diff =
                  (((float (abs (n - z) + 1I)) ** (float sz / 99.0)) - 1.0) * float (sign (n - z))
 
-            bigint (round (float z + diff))
-            |> clamp (toBigInt lo) (toBigInt hi)
-            |> fromBigInt
+            // https://github.com/hedgehogqa/fsharp-hedgehog/issues/185
+            fromBigInt (clamp (toBigInt lo) (toBigInt hi) (bigint (round (float z + diff))))
 
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
@@ -175,10 +174,13 @@ module Range =
     [<CompiledName("ExponentialFrom")>]
     let inline exponentialFrom (z : 'a) (x : 'a) (y : 'a) : Range<'a> =
         Range (z, fun sz ->
+            let scale =
+                // https://github.com/hedgehogqa/fsharp-hedgehog/issues/185
+                scaleExponential x y sz z
             let x_sized =
-                scaleExponential x y sz z x
+                scale x
             let y_sized =
-                scaleExponential x y sz z y
+                scale y
             x_sized, y_sized)
 
     /// Construct a range which scales the second bound exponentially relative

--- a/src/Hedgehog/Range.fs
+++ b/src/Hedgehog/Range.fs
@@ -122,7 +122,7 @@ module Range =
             fromBigInt (z + diff)
 
         /// Scale an integral exponentially with the size parameter.
-        let inline scaleExponential (sz0 : Size) (z0 : 'a) (n0 : 'a) : 'a =
+        let inline scaleExponential (lo : 'a) (hi : 'a) (sz0 : Size) (z0 : 'a) (n0 : 'a) : 'a =
             let sz =
                 clamp 0 99 sz0
 
@@ -135,7 +135,9 @@ module Range =
             let diff =
                  (((float (abs (n - z) + 1I)) ** (float sz / 99.0)) - 1.0) * float (sign (n - z))
 
-            fromBigInt (bigint (round (float z + diff)))
+            bigint (round (float z + diff))
+            |> clamp (toBigInt lo) (toBigInt hi)
+            |> fromBigInt
 
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
@@ -174,9 +176,9 @@ module Range =
     let inline exponentialFrom (z : 'a) (x : 'a) (y : 'a) : Range<'a> =
         Range (z, fun sz ->
             let x_sized =
-                clamp x y (scaleExponential sz z x)
+                scaleExponential x y sz z x
             let y_sized =
-                clamp x y (scaleExponential sz z y)
+                scaleExponential x y sz z y
             x_sized, y_sized)
 
     /// Construct a range which scales the second bound exponentially relative

--- a/tests/Hedgehog.Tests/GenTests.fs
+++ b/tests/Hedgehog.Tests/GenTests.fs
@@ -76,3 +76,17 @@ let ``uint32 doesn't return any out-of-range value`` () =
     let gen = Gen.uint32 <| Range.constant 1ul UInt32.MaxValue
     let actual = Gen.sample 0 100 gen
     test <@ actual |> List.contains 0ul |> not @>
+
+[<Fact>]
+let ``can create exponentially bounded int64`` () =
+    Property.check <| property {
+        let! _ = Gen.int64 (Range.exponentialBounded ())
+        return true
+    }
+
+[<Fact>]
+let ``can create exponentially bounded uint64`` () =
+    Property.check <| property {
+        let! _ = Gen.uint64 (Range.exponentialBounded ())
+        return true
+    }

--- a/tests/Hedgehog.Tests/GenTests.fs
+++ b/tests/Hedgehog.Tests/GenTests.fs
@@ -1,6 +1,5 @@
 ﻿module Hedgehog.Tests.GenTests
 
-open System
 open Hedgehog
 open Swensen.Unquote
 open Xunit
@@ -64,18 +63,6 @@ let ``dateTime shrinks to correct mid-value`` () =
         |> Array.item 1
         |> System.DateTime.Parse
     System.DateTime (2000, 1, 1) =! result
-
-[<Fact>]
-let ``uint64 doesn't return any out-of-range value`` () =
-    let gen = Gen.uint64 <| Range.constant 1UL UInt64.MaxValue
-    let actual = Gen.sample 0 100 gen
-    test <@ actual |> List.contains 0UL |> not @>
-
-[<Fact>]
-let ``uint32 doesn't return any out-of-range value`` () =
-    let gen = Gen.uint32 <| Range.constant 1ul UInt32.MaxValue
-    let actual = Gen.sample 0 100 gen
-    test <@ actual |> List.contains 0ul |> not @>
 
 [<Fact>]
 let ``can create exponentially bounded int64`` () =

--- a/tests/Hedgehog.Tests/GenTests.fs
+++ b/tests/Hedgehog.Tests/GenTests.fs
@@ -65,14 +65,14 @@ let ``dateTime shrinks to correct mid-value`` () =
     System.DateTime (2000, 1, 1) =! result
 
 [<Fact>]
-let ``can create exponentially bounded int64`` () =
+let ``int64 can create exponentially bounded integer`` () =
     Property.check <| property {
         let! _ = Gen.int64 (Range.exponentialBounded ())
         return true
     }
 
 [<Fact>]
-let ``can create exponentially bounded uint64`` () =
+let ``uint64 can create exponentially bounded integer`` () =
     Property.check <| property {
         let! _ = Gen.uint64 (Range.exponentialBounded ())
         return true


### PR DESCRIPTION
https://github.com/hedgehogqa/fsharp-hedgehog/issues/185

The problem looks to be that the clamp on exponential ranges is performed after the conversion to the target type, so if the value falls just outside the range then an exception is thrown before the clamp occurs.

This moves the clamp to before the conversion, but maybe a better fix would be to sort out the calculation that's going out of bounds in the first place.