### PR TITLE
Fix a bug in Shrink.removes where List.take k xs runs before checking k > n

### DIFF
--- a/src/Hedgehog/Shrink.fs
+++ b/src/Hedgehog/Shrink.fs
@@ -23,14 +23,15 @@ module Shrink =
     /// Produce all permutations of removing 'k' elements from a list.
     let removes (k0 : int) (xs0 : List<'a>) : seq<List<'a>> =
         let rec loop (k : int) (n : int) (xs : List<'a>) : seq<List<'a>> =
-            let hd = List.take k xs
-            let tl = List.skip k xs
             if k > n then
                 Seq.empty
-            elif List.isEmpty tl then
-                Seq.singleton List.empty
             else
-                Seq.cons tl (Seq.map (fun x -> List.append hd x) (loop k (n - k) tl))
+              let tl = List.skip k xs
+              if List.isEmpty tl then
+                  Seq.singleton List.empty
+              else
+                  let hd = List.take k xs
+                  Seq.cons tl (Seq.map (fun x -> List.append hd x) (loop k (n - k) tl))
         loop k0 (List.length xs0) xs0
 
     /// Produce a list containing the progressive halving of an integral.

--- a/src/Hedgehog/Shrink.fs
+++ b/src/Hedgehog/Shrink.fs
@@ -23,9 +23,8 @@ module Shrink =
     /// Produce all permutations of removing 'k' elements from a list.
     let removes (k0 : int) (xs0 : List<'a>) : seq<List<'a>> =
         let rec loop (k : int) (n : int) (xs : List<'a>) : seq<List<'a>> =
-            let k1 = Math.Min(k, xs.Length)
-            let hd = List.take k1 xs
-            let tl = List.skip k1 xs
+            let hd = List.take k xs
+            let tl = List.skip k xs
             if k > n then
                 Seq.empty
             elif List.isEmpty tl then


### PR DESCRIPTION
This is more efficient than https://github.com/hedgehogqa/fsharp-hedgehog/commit/27c19dfeed4929d6e62fe6df269797eedcc7e650 as it avoids `Math.Min` entirely. See also #170.