### PR TITLE
make hedgehog fable friendly

### DIFF
--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -69,20 +69,32 @@ module Gen =
     let map (f : 'a -> 'b) (g : Gen<'a>) : Gen<'b> =
         mapTree (Tree.map f) g
 
+#if FABLE_COMPILER
+    [<CompiledName("Map2")>]
+#else
     [<CompiledName("Map")>]
+#endif    
     let map2 (f : 'a -> 'b -> 'c) (gx : Gen<'a>) (gy : Gen<'b>) : Gen<'c> =
         bind gx <| fun x ->
         bind gy <| fun y ->
         constant (f x y)
 
+#if FABLE_COMPILER
+    [<CompiledName("Map3")>]
+#else
     [<CompiledName("Map")>]
+#endif    
     let map3 (f : 'a -> 'b -> 'c -> 'd) (gx : Gen<'a>) (gy : Gen<'b>) (gz : Gen<'c>) : Gen<'d> =
         bind gx <| fun x ->
         bind gy <| fun y ->
         bind gz <| fun z ->
         constant (f x y z)
 
+#if FABLE_COMPILER
+    [<CompiledName("Map4")>]
+#else
     [<CompiledName("Map")>]
+#endif    
     let map4 (f : 'a -> 'b -> 'c -> 'd -> 'e) (gx : Gen<'a>) (gy : Gen<'b>) (gz : Gen<'c>) (gw : Gen<'d>) : Gen<'e> =
         bind gx <| fun x ->
         bind gy <| fun y ->
@@ -94,11 +106,19 @@ module Gen =
     let zip (gx : Gen<'a>) (gy : Gen<'b>) : Gen<'a * 'b> =
         map2 (fun x y -> x, y) gx gy
 
+#if FABLE_COMPILER
+    [<CompiledName("Zip3")>]
+#else
     [<CompiledName("Zip")>]
+#endif    
     let zip3 (gx : Gen<'a>) (gy : Gen<'b>) (gz : Gen<'c>) : Gen<'a * 'b * 'c> =
         map3 (fun x y z -> x, y, z) gx gy gz
 
+#if FABLE_COMPILER
+    [<CompiledName("Zip4")>]
+#else
     [<CompiledName("Zip")>]
+#endif    
     let zip4 (gx : Gen<'a>) (gy : Gen<'b>) (gz : Gen<'c>) (gw : Gen<'d>) : Gen<'a * 'b * 'c * 'd> =
         map4 (fun x y z w -> x, y, z, w) gx gy gz gw
 
@@ -127,12 +147,22 @@ module Gen =
             g
         member __.Bind(m, k) =
             bind m k
+#if FABLE_COMPILER
+        member __.For(xs, k) =
+            let enumerate xs =
+                use xse = (xs :> seq<'a>).GetEnumerator ()
+                let mv = xse.MoveNext
+                let kc = delay (fun () -> k xse.Current)
+                loop mv kc
+            enumerate xs
+#else                
         member __.For(xs, k) =
             let xse = (xs :> seq<'a>).GetEnumerator ()
             using xse <| fun xse ->
                 let mv = xse.MoveNext
                 let kc = delay (fun () -> k xse.Current)
                 loop mv kc
+#endif                
         member __.Combine(m, n) =
             bind m (fun () -> n)
         member __.Delay(f) =

--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
-    <AssemblyVersion>0.8.3.0</AssemblyVersion>
-    <FileVersion>0.8.3.0</FileVersion>
+    <AssemblyVersion>0.8.3.1</AssemblyVersion>
+    <FileVersion>0.8.3.1</FileVersion>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Hedgehog.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Hedgehog/LinqSupport.fs
+++ b/src/Hedgehog/LinqSupport.fs
@@ -48,13 +48,21 @@ module PropertyLinqSupport =
 
     // This supports simple assertions in `select`:
     [<Extension>]
+#if FABLE_COMPILER
+    [<CompiledName("SelectUnit")>]
+#else
     [<CompiledName("Select")>]
+#endif    
     let selectUnit (p : Property<'a>) (f : Action<'a>) : Property<unit> =
         Property.bind p (Property.fromThrowing f.Invoke)
 
     // This supports assertions as `select`:
     [<Extension>]
+#if FABLE_COMPILER
+    [<CompiledName("SelectManyUnit")>]
+#else
     [<CompiledName("SelectMany")>]
+#endif    
     let bind2Unit (pa : Property<'a>) (f : Func<'a, Property<'b>>) (proj : Action<'a, 'b>) : Property<unit> =
         Property.bind pa (fun a ->
             Property.bind (f.Invoke a) (fun b -> Property.fromThrowing proj.Invoke (a, b)))

--- a/src/Hedgehog/Numeric.fs
+++ b/src/Hedgehog/Numeric.fs
@@ -56,8 +56,10 @@ type MinValue =
     static member MinValue (_ : DateTimeOffset, _ : MinValue) =
         DateTimeOffset.MinValue
 
+#if !FABLE_COMPILER
     static member MinValue (_ : TimeSpan, _ : MinValue) =
         TimeSpan.MinValue
+#endif
 
     static member inline Invoke () =
         let inline call_2 (a : ^a, b : ^b) =
@@ -136,8 +138,10 @@ type MaxValue =
     static member MaxValue (_ : DateTimeOffset, _ : MaxValue) =
         DateTimeOffset.MaxValue
 
+#if !FABLE_COMPILER
     static member MaxValue (_ : TimeSpan, _ : MaxValue) =
         TimeSpan.MaxValue
+#endif
 
     static member inline Invoke () =
         let inline call_2 (a : ^a, b : ^b) =
@@ -174,11 +178,13 @@ type FromBigInt =
     static member FromBigInt (_ : int64, _ : FromBigInt) =
         fun (x : bigint) -> int64 x
 
+#if !FABLE_COMPILER
     static member FromBigInt (_ : nativeint , _ : FromBigInt) =
         fun (x : bigint) -> nativeint (int x)
 
     static member FromBigInt (_ : unativeint, _ : FromBigInt) =
         fun (x : bigint) -> unativeint (int x)
+#endif
 
     static member FromBigInt (_ : bigint, _ : FromBigInt) =
         fun (x : bigint) -> x
@@ -230,8 +236,10 @@ type ToBigInt =
     static member ToBigInt (x : int64) =
         bigint x
 
+#if !FABLE_COMPILER
     static member ToBigInt (x : nativeint) =
         bigint (int x)
+#endif
 
     static member ToBigInt (x : byte) =
         bigint (int x)
@@ -239,8 +247,10 @@ type ToBigInt =
     static member ToBigInt (x : uint16) =
         bigint (int x)
 
+#if !FABLE_COMPILER
     static member ToBigInt (x : unativeint) =
         bigint (int x)
+#endif
 
     static member ToBigInt (x : bigint) =
         x

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -151,7 +151,12 @@ module private Pretty =
 
         List.iter (append sb) (Journal.toList journal)
 
+#if FABLE_COMPILER
+        let str = sb.ToString()
+        str.Substring(0, str.Length-1)
+#else
         sb.ToString(0, sb.Length - 1) // exclude extra newline
+#endif        
 
 [<AbstractClass>]
 type HedgehogException (message : string) =
@@ -297,7 +302,12 @@ module Property =
             bind (counterexample (fun () -> sprintf "%A" x)) (fun _ -> try k x with e -> handle e) |> toGen
         Gen.bind gen prepend |> ofGen
 
+#if FABLE_COMPILER
+    [<CompiledName("ForAll_")>]
+#else
     [<CompiledName("ForAll")>]
+
+#endif    
     let forAll' (gen : Gen<'a>) : Property<'a> =
         forAll gen success
 
@@ -320,7 +330,11 @@ module Property =
         | Success _ ->
             OK
 
+#if FABLE_COMPILER
+    [<CompiledName("Report_")>]
+#else    
     [<CompiledName("Report")>]
+#endif    
     let report' (n : int<tests>) (p : Property<unit>) : Report =
         let random = toGen p |> Gen.toRandom
 
@@ -360,7 +374,11 @@ module Property =
     let report (p : Property<unit>) : Report =
         report' 100<tests> p
 
+#if FABLE_COMPILER
+    [<CompiledName("Check_")>]
+#else
     [<CompiledName("Check")>]
+#endif    
     let check' (n : int<tests>) (p : Property<unit>) : unit =
         report' n p
         |> Report.tryRaise
@@ -371,12 +389,20 @@ module Property =
         |> Report.tryRaise
 
     // Overload for ease-of-use from C#
+#if FABLE_COMPILER
+    [<CompiledName("CheckIsTrue")>]
+#else
     [<CompiledName("Check")>]
+#endif    
     let checkBool (g : Property<bool>) : unit =
         bind g ofBool |> check
 
     // Overload for ease-of-use from C#
+#if FABLE_COMPILER
+    [<CompiledName("CheckIsTrue_")>]
+#else
     [<CompiledName("Check")>]
+#endif    
     let checkBool' (n : int<tests>) (g : Property<bool>) : unit =
         bind g ofBool |> check' n
 
@@ -389,7 +415,11 @@ module Property =
         with
         | _ -> failure
 
+#if FABLE_COMPILER
+    [<CompiledName("Print_")>]
+#else
     [<CompiledName("Print")>]
+#endif    
     let print' (n : int<tests>) (p : Property<unit>) : unit =
         report' n p
         |> Report.render

--- a/src/Hedgehog/paket.template
+++ b/src/Hedgehog/paket.template
@@ -3,7 +3,7 @@ type
 id
     Hedgehog
 version
-	0.8.3.0
+	0.8.3.1
 description
     Hedgehog will eat all your bugs.
 authors
@@ -20,3 +20,6 @@ iconUrl
     https://github.com/hedgehogqa/fsharp-hedgehog/raw/master/img/hedgehog-logo.png
 tags
     fsharp, f#, testing
+files
+    *.fsproj ==> fable/
+    **/*.fs ==> fable/


### PR DESCRIPTION
Hi,

I tried compiling hedghog with fable compilert and it didn't work.
Here I made some changes to make it fable friendly.

I tested it by creating a nuget package and using it with fable.mocha.

Please look over the changes if everything is OK for you.

Some notes (optional read :-)):
I had some troubles building fsharp-hedghog on windows and had to start linux docker image to build the nuget package. Is this a known problem? In linux world I had to use paket as local tool to make it work. If this is something you would like to have tell me and I will make another pull request for paket as local tool (this works only with the new .net core sdk 3.1 maybe 3.0).

