### PR TITLE
exclude obj directories from nuget package

### DIFF
--- a/src/Hedgehog/paket.template
+++ b/src/Hedgehog/paket.template
@@ -23,3 +23,4 @@ tags
 files
     *.fsproj ==> fable/
     **/*.fs ==> fable/
+    !obj/**/*.*


### PR DESCRIPTION
Hi,

as you already noticed we have some generated files from obj folder also packed in the nuget package into fable folder.

I do not think fable compiler needs this.

I just added to ignore all files from obj folder when generating nuget package.

Hope this is OK.