### PR TITLE
Make Hedgehog.Benchmarks the default startup project

### DIFF
--- a/Hedgehog.sln
+++ b/Hedgehog.sln
@@ -8,13 +8,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Hedgehog.Benchmarks", "tests/Hedgehog.Benchmarks/Hedgehog.Benchmarks.fsproj", "{7E2DE9D9-3831-46D7-B80F-B643E9D53FD3}"
+EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Hedgehog", "src/Hedgehog/Hedgehog.fsproj", "{0864FFED-D0B3-4D32-BD38-DB696B7FC5F3}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Hedgehog.Tests", "tests/Hedgehog.Tests/Hedgehog.Tests.fsproj", "{D38AB54A-D5E8-4B50-927C-472015473AFC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hedgehog.CSharp.Tests", "tests/Hedgehog.CSharp.Tests/Hedgehog.CSharp.Tests.csproj", "{952547C5-7622-45C8-BB3C-4D1BA2DB747D}"
-EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Hedgehog.Benchmarks", "tests/Hedgehog.Benchmarks/Hedgehog.Benchmarks.fsproj", "{7E2DE9D9-3831-46D7-B80F-B643E9D53FD3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This PR makes the `Hedgehog.Benchmarks` project the default startup project by listing it first in the `sln` file.

This change improves the development experience. When first cloning the repo or after deleting the `.vs` directory and then opening the `sln` file with Visual Studio, the default startup project will now be the `Hedgehog.Benchmarks` project. This is an improvement because the `Hedgehog` project was the previous default startup project, but it cannot be executed.  (The two test projects can be started/executed, but I do not believe that it is intended behavior to do so.)