### PR TITLE
Add test to ensure that genExp is not its default value

### DIFF
--- a/tests/Hedgehog.Tests/MinimalTests.fs
+++ b/tests/Hedgehog.Tests/MinimalTests.fs
@@ -62,6 +62,27 @@ let rec genExp : Gen<Exp> =
         App <!> Gen.zip genExp genExp
     ]
 
+let isDefaultGen g =
+  let f =
+    match g with
+    | Gen (Random f) -> f
+  obj.ReferenceEquals(f, null)
+
+// https://github.com/hedgehogqa/fsharp-hedgehog/pull/202/
+[<Fact>]
+let ``isDefaultGen returns true for default value of Gen<Exp>``() =
+    test <@ Unchecked.defaultof<Gen<Exp>> |> isDefaultGen @>
+
+// https://github.com/hedgehogqa/fsharp-hedgehog/pull/202/
+[<Fact>]
+let ``isDefaultGen returns false for constant Gen<Exp> Lit 0``() =
+    test <@ 0 |> Lit |> Gen.constant |> isDefaultGen |> not @>
+
+// https://github.com/hedgehogqa/fsharp-hedgehog/pull/202/
+[<Fact>]
+let ``genExp is not its default value``() =
+    test <@ genExp |> isDefaultGen |> not @>
+
 [<Fact>]
 let ``greedy traversal with a predicate yields the perfect minimal shrink``() =
     Property.check <| property {


### PR DESCRIPTION
This PR is related to issue #201 about the possibility of a test failing in the `master` branch.

For me, that test fails, and it fails very "late" in its execution.  I eventually determined that it fails because the reference it obtains to `genExp` is its `default` value.  (After realizing that, I found it easier to debug the failing test after removing `[<Struct>]` from the definitions of `Gen<>` and `Random<>`.  Then the test failed significantly sooner in its execution.)

This PR adds a test to ensure that `genExp` is not its default value (when `Gen<>` and `Random<>` are still defined with `[<Struct>]`... this test will fail if `[<Struct>]` is removed from the definition of either of those types).  It also adds some tests to ensure that the `isDefaultGen` test is implemented correctly.

It think it makes sense to merge this now before coming to a conclusion about issue #201 ~. Either something about my development environment is broken, which is causing that test in the `master` branch to fail, and so these new tests also pass for everyone else.  Or my development environment has identified a legitimate issue with that test, and so these new tests help to focus debugging efforts.~ since [the build triggered on travis ci by this PR passed](https://travis-ci.org/github/hedgehogqa/fsharp-hedgehog/builds/704290516).