### PR TITLE
Target .NET Standard 2.0

### DIFF
--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
     <Version>0.8.3</Version>
     <Description>Release with confidence.</Description>
     <Authors>Jacob Stanley;Nikos Baxevanis</Authors>


### PR DESCRIPTION
Fixes #204

I tested creation of the NuGet package by executing the command...
```
dotnet pack src/Hedgehog/Hedgehog.fsproj
```

...and it produced a NuGet package that listed these dependencies.
![2020-07-10_15-16-20_159_devenv](https://user-images.githubusercontent.com/34664007/87198722-77583400-c2c0-11ea-8317-513e549949f7.png)

I think this the correct behavior.