### PR TITLE
Also target net45

### DIFF
--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <Version>0.8.3</Version>
     <Description>Release with confidence.</Description>
     <Authors>Jacob Stanley;Nikos Baxevanis</Authors>

--- a/tests/Hedgehog.CSharp.Tests/Hedgehog.CSharp.Tests.csproj
+++ b/tests/Hedgehog.CSharp.Tests/Hedgehog.CSharp.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />

--- a/tests/Hedgehog.Tests/GenTests.fs
+++ b/tests/Hedgehog.Tests/GenTests.fs
@@ -59,7 +59,7 @@ let ``dateTime shrinks to correct mid-value`` () =
         }
         |> Property.report
         |> Report.render
-        |> (fun x -> x.Split System.Environment.NewLine)
+        |> (fun x -> x.Split ([|System.Environment.NewLine|], System.StringSplitOptions.None))
         |> Array.item 1
         |> System.DateTime.Parse
     System.DateTime (2000, 1, 1) =! result

--- a/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
+++ b/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes #199 

The test projects target .NET Framework 4.6.1 since since this is the lowest version that has the issue I described in https://github.com/hedgehogqa/fsharp-hedgehog/issues/199#issue-648491997.

The main project targets .NET Framework 4.5 because that was the lowest version that worked for me.  I tried targeting version 4.0.3, but I got an error message saying something about needing to install an SDK.  I didn't feel like trying any harder than that.  Someone else can create a new issue if they want to investigate Hedgehog targeting version 4.0.3 or lower.

In the penultimate commit, I have 11 failing tests.  All are because a `MissingMethodException` was thrown.  None of them have the same message as the one I experienced in https://github.com/elmish/Elmish.WPF/issues/237, but I also verified that one of those tests now passes after I changed my dependency on Hedgehog from a NuGet package reference to a project reference (while the project was using the branch in this PR).  All tests in this repo pass for me when on the head of the branch in this PR.

After the new Hedgehog NuGet package is released, I will certainly update to it, test again, and report back.