### PR TITLE
Release 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@
 [porges]:
   https://github.com/porges
 
+[186]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/186
 [173]:
   https://github.com/hedgehogqa/fsharp-hedgehog/pull/173
 [165]:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 0.8.4 (2020-07-26)
+
+- Add target .NET Framework 4.5 ([#210][210], [@bender2k14][bender2k14])
+- Add target .NET Standard 2.0 ([#209][209], [@bender2k14][bender2k14])
+
 ## Version 0.8.3 (2019-07-09)
 
 - Improve Int64 value generation (avoid overflows) ([#186][186], [@marklam][marklam])
@@ -73,6 +78,8 @@
 
 - First release of Hedgehog ([@jystic][jystic], [@moodmosaic][moodmosaic])
 
+[bender2k14]:
+  https://github.com/bender2k14
 [frankshearar]:
   https://github.com/frankshearar
 [jystic]:
@@ -88,6 +95,10 @@
 [porges]:
   https://github.com/porges
 
+[210]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/210
+[209]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/209
 [186]:
   https://github.com/hedgehogqa/fsharp-hedgehog/pull/186
 [173]:

--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net45</TargetFrameworks>
-    <Version>0.8.3</Version>
+    <Version>0.8.4</Version>
     <Description>Release with confidence.</Description>
     <Authors>Jacob Stanley;Nikos Baxevanis</Authors>
     <Copyright>Copyright © 2017</Copyright>


### PR DESCRIPTION
Compared to the [previous release (0.8.3)](https://github.com/hedgehogqa/fsharp-hedgehog/pull/188/files), there two differences.
1. Only changed the `Verson` element in `Hedgehog.fsproj` instead of both `AssemblyVersion` and `FileVersion` because of the change in c90f5a280b69a1856488f8275cd4934e18890bfd.
2. No change in `paket.template` because it doesn't exist anymore (c.f. #207).