### PR TITLE
Add Tree to string function

### DIFF
--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -224,6 +224,7 @@ module Gen =
     }
 
     /// Uses a weighted distribution to randomly select one of the gens in the list.
+    /// This generator shrinks towards the first generator in the list.
     /// <i>The input list must be non-empty.</i>
     [<CompiledName("Frequency")>]
     let frequency (xs0 : seq<int * Gen<'a>>) : Gen<'a> = gen {

--- a/src/Hedgehog/Tree.fs
+++ b/src/Hedgehog/Tree.fs
@@ -89,23 +89,28 @@ module Tree =
         Seq.filter (f << outcome) xs
         |> Seq.map (filter f)
 
-    let rec renderLines (Node (x, xs) : Tree<string>) : string list =
-        let mapFirstDifferently f g = function
-            | [] -> []
-            | x :: xs -> (f x) :: (xs |> List.map g)
-        let mapLastDifferently f g = List.rev >> mapFirstDifferently g f >> List.rev
-        let tail =
-            xs
-            |> Seq.map renderLines
-            |> Seq.toList
-            |> mapLastDifferently
-                (mapFirstDifferently ((+) "├-")
-                                     ((+) "| "))
-                (mapFirstDifferently ((+) "└-")
-                                     ((+) "  "))
+    let rec renderLines (Node (x, xs00) : Tree<string>) : List<string> =
+        // zipWith (++) (hd : repeat other)
+        let shift f g xs0 =
+            match xs0 with
+            | [] ->
+                []
+            | x :: xs ->
+                (f x) :: (List.map g xs)
+
+        let xs =
+            xs00
+            |> List.ofSeq
+            |> List.map renderLines
+            |> shift
+                   (shift ((+) "├-") ((+) "| "))
+                   (shift ((+) "└-") ((+) "  "))
             |> List.concat
             |> List.map ((+) " ")
-        x :: tail
+
+        x :: xs
 
     let render (t : Tree<string>) : string =
-        renderLines t |> Seq.reduce (fun a b -> a + System.Environment.NewLine + b)
+        renderLines t
+        |> Seq.reduce (fun a b ->
+            a + System.Environment.NewLine + b)

--- a/src/Hedgehog/Tree.fs
+++ b/src/Hedgehog/Tree.fs
@@ -88,3 +88,24 @@ module Tree =
     and filterForest (f : 'a -> bool) (xs : seq<Tree<'a>>) : seq<Tree<'a>> =
         Seq.filter (f << outcome) xs
         |> Seq.map (filter f)
+
+    let rec renderLines (Node (x, xs) : Tree<string>) : string list =
+        let mapFirstDifferently f g = function
+            | [] -> []
+            | x :: xs -> (f x) :: (xs |> List.map g)
+        let mapLastDifferently f g = List.rev >> mapFirstDifferently g f >> List.rev
+        let tail =
+            xs
+            |> Seq.map renderLines
+            |> Seq.toList
+            |> mapLastDifferently
+                (mapFirstDifferently ((+) "├-")
+                                     ((+) "| "))
+                (mapFirstDifferently ((+) "└-")
+                                     ((+) "  "))
+            |> List.concat
+            |> List.map ((+) " ")
+        x :: tail
+
+    let render (t : Tree<string>) : string =
+        renderLines t |> Seq.reduce (fun a b -> a + System.Environment.NewLine + b)

--- a/src/Hedgehog/Tree.fs
+++ b/src/Hedgehog/Tree.fs
@@ -89,7 +89,7 @@ module Tree =
         Seq.filter (f << outcome) xs
         |> Seq.map (filter f)
 
-    let rec renderLines (Node (x, xs00) : Tree<string>) : List<string> =
+    let rec renderList (Node (x, xs00) : Tree<string>) : List<string> =
         // zipWith (++) (hd : repeat other)
         let shift f g xs0 =
             match xs0 with
@@ -101,7 +101,7 @@ module Tree =
         let xs =
             xs00
             |> List.ofSeq
-            |> List.map renderLines
+            |> List.map renderList
             |> shift
                    (shift ((+) "├-") ((+) "| "))
                    (shift ((+) "└-") ((+) "  "))
@@ -111,6 +111,6 @@ module Tree =
         x :: xs
 
     let render (t : Tree<string>) : string =
-        renderLines t
+        renderList t
         |> Seq.reduce (fun a b ->
             a + System.Environment.NewLine + b)

--- a/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
+++ b/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
@@ -1,10 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="TreeTests.fs" />
     <Compile Include="RangeTests.fs" />
     <Compile Include="GenTests.fs" />
     <Compile Include="SeedTests.fs" />

--- a/tests/Hedgehog.Tests/TreeTests.fs
+++ b/tests/Hedgehog.Tests/TreeTests.fs
@@ -5,54 +5,75 @@ open Swensen.Unquote
 open Xunit
 
 [<Fact>]
-let ``render of singleton tree`` () =
+let ``render tree with depth 0`` () =
     Property.check <| property {
-        let! v = Gen.uint64 (Range.exponentialBounded ())
-        let tree = Tree.singleton v |> Tree.map (sprintf "%A")
-        let expected = sprintf "%A" v
-        test <@ expected = Tree.render tree @>
-    }
+        let! x0 = Gen.constant "0"
 
-[<Fact>]
-let ``renderLines of binary tree with depth 1`` () =
-    Property.check <| property {
-        let! v = Gen.uint64 (Range.exponentialBounded ())
-        let! v0 = Gen.uint64 (Range.exponentialBounded ())
-        let! v1 = Gen.uint64 (Range.exponentialBounded ())
         let tree =
-            Node (v, [ v0; v1 ] |> Seq.map Tree.singleton)
+            Node (x0, [
+            ])
             |> Tree.map (sprintf "%A")
+
         let expected = [
-            sprintf "%A" v
-            sprintf " ├-%A" v0
-            sprintf " └-%A" v1
+            sprintf "%A" x0
         ]
         test <@ expected = Tree.renderLines tree @>
     }
 
 [<Fact>]
-let ``renderLines of binary tree with depth 2`` () =
+let ``render tree with depth 1`` () =
     Property.check <| property {
-        let! v = Gen.uint64 (Range.exponentialBounded ())
-        let! v0 = Gen.uint64 (Range.exponentialBounded ())
-        let! v1 = Gen.uint64 (Range.exponentialBounded ())
-        let! v00 = Gen.uint64 (Range.exponentialBounded ())
-        let! v01 = Gen.uint64 (Range.exponentialBounded ())
-        let! v10 = Gen.uint64 (Range.exponentialBounded ())
-        let! v11 = Gen.uint64 (Range.exponentialBounded ())
-        let v0Children = Node (v0, [ v00; v01 ] |> Seq.map Tree.singleton)
-        let v1Children = Node (v1, [ v10; v11 ] |> Seq.map Tree.singleton)
+        let! x0 = Gen.constant "0"
+        let! x1 = Gen.constant "1"
+        let! x2 = Gen.constant "2"
+
         let tree =
-            Node (v, [ v0Children; v1Children ])
+            Node (x0, [
+                Node (x1, [])
+                Node (x2, [])
+            ])
             |> Tree.map (sprintf "%A")
+
         let expected = [
-            sprintf "%A" v
-            sprintf " ├-%A" v0
-            sprintf " |  ├-%A" v00
-            sprintf " |  └-%A" v01
-            sprintf " └-%A" v1
-            sprintf "    ├-%A" v10
-            sprintf "    └-%A" v11
+            sprintf "%A" x0
+            sprintf " ├-%A" x1
+            sprintf " └-%A" x2
+        ]
+        test <@ expected = Tree.renderLines tree @>
+    }
+
+[<Fact>]
+let ``render tree with depth 2`` () =
+    Property.check <| property {
+        let! x0 = Gen.constant "0"
+        let! x1 = Gen.constant "1"
+        let! x2 = Gen.constant "2"
+        let! x3 = Gen.constant "3"
+        let! x4 = Gen.constant "4"
+        let! x5 = Gen.constant "5"
+        let! x6 = Gen.constant "6"
+
+        let tree =
+            Node (x0, [
+                Node (x1, [
+                    Node (x3, [])
+                    Node (x5, [])
+                ])
+                Node (x2, [
+                    Node (x4, [])
+                    Node (x6, [])
+                ])
+            ])
+            |> Tree.map (sprintf "%A")
+
+        let expected = [
+            sprintf "%A" x0
+            sprintf " ├-%A" x1
+            sprintf " |  ├-%A" x3
+            sprintf " |  └-%A" x5
+            sprintf " └-%A" x2
+            sprintf "    ├-%A" x4
+            sprintf "    └-%A" x6
         ]
         test <@ expected = Tree.renderLines tree @>
     }

--- a/tests/Hedgehog.Tests/TreeTests.fs
+++ b/tests/Hedgehog.Tests/TreeTests.fs
@@ -17,7 +17,7 @@ let ``render tree with depth 0`` () =
         let expected = [
             sprintf "%A" x0
         ]
-        test <@ expected = Tree.renderLines tree @>
+        test <@ expected = Tree.renderList tree @>
     }
 
 [<Fact>]
@@ -39,7 +39,7 @@ let ``render tree with depth 1`` () =
             sprintf " ├-%A" x1
             sprintf " └-%A" x2
         ]
-        test <@ expected = Tree.renderLines tree @>
+        test <@ expected = Tree.renderList tree @>
     }
 
 [<Fact>]
@@ -75,5 +75,5 @@ let ``render tree with depth 2`` () =
             sprintf "    ├-%A" x4
             sprintf "    └-%A" x6
         ]
-        test <@ expected = Tree.renderLines tree @>
+        test <@ expected = Tree.renderList tree @>
     }

--- a/tests/Hedgehog.Tests/TreeTests.fs
+++ b/tests/Hedgehog.Tests/TreeTests.fs
@@ -1,0 +1,58 @@
+﻿module Hedgehog.Tests.TreeTests
+
+open Hedgehog
+open Swensen.Unquote
+open Xunit
+
+[<Fact>]
+let ``render of singleton tree`` () =
+    Property.check <| property {
+        let! v = Gen.uint64 (Range.exponentialBounded ())
+        let tree = Tree.singleton v |> Tree.map (sprintf "%A")
+        let expected = sprintf "%A" v
+        test <@ expected = Tree.render tree @>
+    }
+
+[<Fact>]
+let ``renderLines of binary tree with depth 1`` () =
+    Property.check <| property {
+        let! v = Gen.uint64 (Range.exponentialBounded ())
+        let! v0 = Gen.uint64 (Range.exponentialBounded ())
+        let! v1 = Gen.uint64 (Range.exponentialBounded ())
+        let tree =
+            Node (v, [ v0; v1 ] |> Seq.map Tree.singleton)
+            |> Tree.map (sprintf "%A")
+        let expected = [
+            sprintf "%A" v
+            sprintf " ├-%A" v0
+            sprintf " └-%A" v1
+        ]
+        test <@ expected = Tree.renderLines tree @>
+    }
+
+[<Fact>]
+let ``renderLines of binary tree with depth 2`` () =
+    Property.check <| property {
+        let! v = Gen.uint64 (Range.exponentialBounded ())
+        let! v0 = Gen.uint64 (Range.exponentialBounded ())
+        let! v1 = Gen.uint64 (Range.exponentialBounded ())
+        let! v00 = Gen.uint64 (Range.exponentialBounded ())
+        let! v01 = Gen.uint64 (Range.exponentialBounded ())
+        let! v10 = Gen.uint64 (Range.exponentialBounded ())
+        let! v11 = Gen.uint64 (Range.exponentialBounded ())
+        let v0Children = Node (v0, [ v00; v01 ] |> Seq.map Tree.singleton)
+        let v1Children = Node (v1, [ v10; v11 ] |> Seq.map Tree.singleton)
+        let tree =
+            Node (v, [ v0Children; v1Children ])
+            |> Tree.map (sprintf "%A")
+        let expected = [
+            sprintf "%A" v
+            sprintf " ├-%A" v0
+            sprintf " |  ├-%A" v00
+            sprintf " |  └-%A" v01
+            sprintf " └-%A" v1
+            sprintf "    ├-%A" v10
+            sprintf "    └-%A" v11
+        ]
+        test <@ expected = Tree.renderLines tree @>
+    }


### PR DESCRIPTION
Resolves #227

(This PR was previously PR #228 with a different branch name)

This gets the job done. I am open to feedback to adhere to the standards of the project or the preferences of the maintainers.

Based on comment https://github.com/hedgehogqa/fsharp-hedgehog/issues/226#issuecomment-719817482 by @moodmosaic, I named these functions `render` (instead of `toString` like in PR #228).

After looking more closely at the Haskell code, the function that returns `string list` I named `renderLines`.  I also restricted these functions to only work for trees containing data of type `string`.