### PR TITLE
Reduce noise from GitHub's unchanged files with check annotations feature

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.1.4
+        dotnet-version: 3.1.403
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/tests/Hedgehog.Benchmarks/Hedgehog.Benchmarks.fsproj
+++ b/tests/Hedgehog.Benchmarks/Hedgehog.Benchmarks.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Hedgehog.CSharp.Tests/Hedgehog.CSharp.Tests.csproj
+++ b/tests/Hedgehog.CSharp.Tests/Hedgehog.CSharp.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />

--- a/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
+++ b/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR upgrades the CI build to use version 3.1.403 of the .NET SDK.  This is the most recently released version.  The CI build is currently using version 2.1.4.  Both the 2.1 series and the 3.1 series are long-term support (LTS) releases.

I have created this PR to resolve the FS0058 warnings, which are about possibly incorrect indentations.  The F# compiler in the newer SDK is satisfied with the current indentation.

Most practically, this PR will remove these warnings from the files view of a pull request in GitHub.  A beta feature of GitHub under the heading [Unchanged files with check annotations](https://github.com/hedgehogqa/fsharp-hedgehog/pull/233/files#diff-9b7fcde4f0a23cc861c6b1da4c00e8eaf668e9db5a0b07ae8ab2527e3a76373fR66:~:text=Unchanged%20files%20with%20check%20annotations) shows the lines with these warnings.