### PR TITLE
Fix Tree.render bug

### DIFF
--- a/src/Hedgehog/Tree.fs
+++ b/src/Hedgehog/Tree.fs
@@ -89,22 +89,20 @@ module Tree =
         Seq.filter (f << outcome) xs
         |> Seq.map (filter f)
 
-    let rec renderList (Node (x, xs00) : Tree<string>) : List<string> =
-        // zipWith (++) (hd : repeat other)
-        let shift f g xs0 =
-            match xs0 with
-            | [] ->
-                []
-            | x :: xs ->
-                (f x) :: (List.map g xs)
-
+    let rec renderList (Node (x, xs0) : Tree<string>) : List<string> =
+        let mapFirstDifferently f g = function
+            | [] -> []
+            | x :: xs -> (f x) :: (xs |> List.map g)
+        let mapLastDifferently f g = List.rev >> mapFirstDifferently g f >> List.rev
         let xs =
-            xs00
-            |> List.ofSeq
-            |> List.map renderList
-            |> shift
-                   (shift ((+) "├-") ((+) "| "))
-                   (shift ((+) "└-") ((+) "  "))
+            xs0
+            |> Seq.map renderList
+            |> Seq.toList
+            |> mapLastDifferently
+                (mapFirstDifferently ((+) "├-")
+                                     ((+) "| "))
+                (mapFirstDifferently ((+) "└-")
+                                     ((+) "  "))
             |> List.concat
             |> List.map ((+) " ")
 

--- a/tests/Hedgehog.Tests/TreeTests.fs
+++ b/tests/Hedgehog.Tests/TreeTests.fs
@@ -26,18 +26,21 @@ let ``render tree with depth 1`` () =
         let! x0 = Gen.constant "0"
         let! x1 = Gen.constant "1"
         let! x2 = Gen.constant "2"
+        let! x3 = Gen.constant "3"
 
         let tree =
             Node (x0, [
                 Node (x1, [])
                 Node (x2, [])
+                Node (x3, [])
             ])
             |> Tree.map (sprintf "%A")
 
         let expected = [
             sprintf "%A" x0
             sprintf " ├-%A" x1
-            sprintf " └-%A" x2
+            sprintf " ├-%A" x2
+            sprintf " └-%A" x3
         ]
         test <@ expected = Tree.renderList tree @>
     }
@@ -52,16 +55,29 @@ let ``render tree with depth 2`` () =
         let! x4 = Gen.constant "4"
         let! x5 = Gen.constant "5"
         let! x6 = Gen.constant "6"
+        let! x7 = Gen.constant "7"
+        let! x8 = Gen.constant "8"
+        let! x9 = Gen.constant "9"
+        let! x10 = Gen.constant "10"
+        let! x11 = Gen.constant "11"
+        let! x12 = Gen.constant "12"
 
         let tree =
             Node (x0, [
                 Node (x1, [
-                    Node (x3, [])
+                    Node (x4, [])
                     Node (x5, [])
+                    Node (x6, [])
                 ])
                 Node (x2, [
-                    Node (x4, [])
-                    Node (x6, [])
+                    Node (x7, [])
+                    Node (x8, [])
+                    Node (x9, [])
+                ])
+                Node (x3, [
+                    Node (x10, [])
+                    Node (x11, [])
+                    Node (x12, [])
                 ])
             ])
             |> Tree.map (sprintf "%A")
@@ -69,11 +85,17 @@ let ``render tree with depth 2`` () =
         let expected = [
             sprintf "%A" x0
             sprintf " ├-%A" x1
-            sprintf " |  ├-%A" x3
-            sprintf " |  └-%A" x5
-            sprintf " └-%A" x2
-            sprintf "    ├-%A" x4
-            sprintf "    └-%A" x6
+            sprintf " |  ├-%A" x4
+            sprintf " |  ├-%A" x5
+            sprintf " |  └-%A" x6
+            sprintf " ├-%A" x2
+            sprintf " |  ├-%A" x7
+            sprintf " |  ├-%A" x8
+            sprintf " |  └-%A" x9
+            sprintf " └-%A" x3
+            sprintf "    ├-%A" x10
+            sprintf "    ├-%A" x11
+            sprintf "    └-%A" x12
         ]
         test <@ expected = Tree.renderList tree @>
     }


### PR DESCRIPTION
@moodmosaic, I just realized that you introduced a bug when you changed the implementation of `Tree.renderList` in PR #229.

This PR contains two commits.  The first commit increases the cases covered by the tests by changing the trees in the tests from full binary trees to full ternary trees.  The second commit reverts the implementation of `Tree.renderList` to how [my commit](https://github.com/hedgehogqa/fsharp-hedgehog/pull/229/commits/20d328df67e3def0a0e48b3875085e33237b0aca) computed the output.

In the second commit, I tried to keep all of your copy edits.  I am just trying to get back to an implementation that passes the tests.  Feel free to change it however you want again (but this time, try to not add a bug ;) :P ).