### PR TITLE
Improved integral shrink trees to match behavior of binary search

### DIFF
--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -163,26 +163,9 @@ module Gen =
 
     /// Generates a random number in the given inclusive range.
     let inline integral (range : Range<'a>) : Gen<'a> =
-        let mapFirstDifferently f g = function
-            | [] -> []
-            | x :: xs -> (f x) :: (xs |> List.map g)
-        let rec createTree (destination : ^a) (x : ^a) =
-          let childrenValues =
-              match Shrink.towards destination x |> Seq.toList with
-              | [] -> []
-              | x :: [] -> List.singleton x
-              | _ :: xs -> xs
-          let xs =
-              childrenValues
-              |> Seq.cons destination
-              |> Seq.pairwise
-              |> Seq.toList
-              |> mapFirstDifferently id (fun (d, x) -> (d + LanguagePrimitives.GenericOne, x))
-              |> Seq.map (fun (d, x) -> createTree d x)
-          Node (x, xs)
         range
         |> Random.integral
-        |> Random.map (range |> Range.origin |> createTree)
+        |> Random.map (range |> Range.origin |> Shrink.createTree)
         |> ofRandom
 
     //

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -163,11 +163,27 @@ module Gen =
 
     /// Generates a random number in the given inclusive range.
     let inline integral (range : Range<'a>) : Gen<'a> =
-        let shrink =
-            Shrink.towards (Range.origin range)
-
-        Random.integral range
-        |> create shrink
+        let mapFirstDifferently f g = function
+            | [] -> []
+            | x :: xs -> (f x) :: (xs |> List.map g)
+        let rec createTree (destination : ^a) (x : ^a) =
+          let childrenValues =
+              match Shrink.towards destination x |> Seq.toList with
+              | [] -> []
+              | x :: [] -> List.singleton x
+              | _ :: xs -> xs
+          let xs =
+              childrenValues
+              |> Seq.cons destination
+              |> Seq.pairwise
+              |> Seq.toList
+              |> mapFirstDifferently id (fun (d, x) -> (d + LanguagePrimitives.GenericOne, x))
+              |> Seq.map (fun (d, x) -> createTree d x)
+          Node (x, xs)
+        range
+        |> Random.integral
+        |> Random.map (range |> Range.origin |> createTree)
+        |> ofRandom
 
     //
     // Combinators - Choice

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -163,6 +163,7 @@ module Gen =
 
     /// Generates a random number in the given inclusive range.
     let inline integral (range : Range<'a>) : Gen<'a> =
+        // https://github.com/hedgehogqa/fsharp-hedgehog/pull/239
         range
         |> Random.integral
         |> Random.map (range |> Range.origin |> Shrink.createTree)

--- a/src/Hedgehog/Seq.fs
+++ b/src/Hedgehog/Seq.fs
@@ -15,3 +15,6 @@ let inline consNub (x : 'a) (ys0 : seq<'a>) : seq<'a> =
             ys0
         else
             cons x ys0
+
+let inline join (xss: 'a seq seq) : seq<'a> =
+    Seq.collect id xss

--- a/src/Hedgehog/Shrink.fs
+++ b/src/Hedgehog/Shrink.fs
@@ -1,4 +1,4 @@
-﻿namespace Hedgehog
+namespace Hedgehog
 
 
 module Shrink =
@@ -98,3 +98,19 @@ module Shrink =
                     None
 
             Seq.unfold go diff
+
+
+    let inline createTree (destination : ^a) (x : ^a) =
+        let mapFirstDifferently f g = function
+            | [] -> []
+            | x :: xs -> (f x) :: (xs |> List.map g)
+        let rec binarySearchTree (destination : ^a) (x : ^a) =
+            let xs =
+                towards destination x
+                |> Seq.cons destination
+                |> Seq.pairwise
+                |> Seq.toList
+                |> mapFirstDifferently id (fun (d, x) -> (d + LanguagePrimitives.GenericOne, x))
+                |> Seq.map (fun (d, x) -> binarySearchTree d x)
+            Node (x, xs)
+        binarySearchTree destination x

--- a/src/Hedgehog/Shrink.fs
+++ b/src/Hedgehog/Shrink.fs
@@ -100,11 +100,9 @@ module Shrink =
 
 
     let inline createTree (destination : ^a) (x : ^a) =
-        let one = LanguagePrimitives.GenericOne
         let rec binarySearchTree ((destination : ^a), (x : ^a)) =
             let xs =
-                towards (destination + one) x
-                |> Seq.cons destination
+                towards destination x
                 |> Seq.pairwise
                 |> Seq.map binarySearchTree
             Node (x, xs)

--- a/src/Hedgehog/Shrink.fs
+++ b/src/Hedgehog/Shrink.fs
@@ -102,13 +102,13 @@ module Shrink =
         let one = LanguagePrimitives.GenericOne
         let rec binarySearchTree (destination : ^a) (x : ^a) =
             let xs =
-                towards destination x
-                |> Seq.cons (destination - one)
+                towards (destination + one) x
+                |> Seq.cons destination
                 |> Seq.pairwise
-                |> Seq.map (fun (d, x) -> binarySearchTree (d + one) x)
+                |> Seq.map (fun (d, x) -> binarySearchTree d x)
             Node (x, xs)
         if destination = x then
             Node (x, Seq.empty)
         else
-            binarySearchTree (destination + one) x
+            binarySearchTree destination x
             |> Tree.addChildValue destination

--- a/src/Hedgehog/Shrink.fs
+++ b/src/Hedgehog/Shrink.fs
@@ -66,18 +66,19 @@ module Shrink =
 
     /// Shrink an integral number by edging towards a destination.
     let inline towards (destination : ^a) (x : ^a) : seq<'a> =
-        let one : ^a = LanguagePrimitives.GenericOne
-        let two : ^a = one + one
         if destination = x then
             Seq.empty
-        elif destination = x - one then
-            Seq.singleton destination
         else
+            let one : ^a = LanguagePrimitives.GenericOne
+            let two : ^a = one + one
+
             /// We need to halve our operands before subtracting them as they may be using
             /// the full range of the type (i.e. 'MinValue' and 'MaxValue' for 'Int32')
             let diff : ^a = (x / two) - (destination / two)
+
             halves diff
             |> Seq.map (fun y -> x - y)
+            |> Seq.consNub destination
 
     /// Shrink a floating-point number by edging towards a destination.
     /// Note we always try the destination first, as that is the optimal shrink.

--- a/src/Hedgehog/Shrink.fs
+++ b/src/Hedgehog/Shrink.fs
@@ -100,15 +100,15 @@ module Shrink =
 
     let inline createTree (destination : ^a) (x : ^a) =
         let one = LanguagePrimitives.GenericOne
-        let rec binarySearchTree (destination : ^a) (x : ^a) =
+        let rec binarySearchTree ((destination : ^a), (x : ^a)) =
             let xs =
                 towards (destination + one) x
                 |> Seq.cons destination
                 |> Seq.pairwise
-                |> Seq.map (fun (d, x) -> binarySearchTree d x)
+                |> Seq.map binarySearchTree
             Node (x, xs)
         if destination = x then
             Node (x, Seq.empty)
         else
-            binarySearchTree destination x
+            binarySearchTree (destination, x)
             |> Tree.addChildValue destination

--- a/src/Hedgehog/Tree.fs
+++ b/src/Hedgehog/Tree.fs
@@ -21,6 +21,19 @@ module Tree =
     let singleton (x : 'a) : Tree<'a> =
         Node (x, Seq.empty)
 
+    let addChild (child: Tree<'a>) (parent: Tree<'a>) : Tree<'a> =
+        let (Node (x, xs)) = parent
+        Node (x, Seq.cons child xs)
+
+    let addChildValue (a: 'a) (tree: Tree<'a>) : Tree<'a> =
+        tree |> addChild (singleton a)
+
+    let rec cata (f: 'a -> 'b seq -> 'b) (Node (x, xs): Tree<'a>) : 'b =
+        f x (Seq.map (cata f) xs)
+
+    let toSeq (tree: Tree<'a>) : 'a seq =
+        tree |> cata (fun a -> Seq.join >> Seq.cons a)
+
     /// Map over a tree.
     let rec map (f : 'a -> 'b) (Node (x, xs) : Tree<'a>) : Tree<'b> =
         Node (f x, Seq.map (map f) xs)

--- a/tests/Hedgehog.Tests/ShrinkTests.fs
+++ b/tests/Hedgehog.Tests/ShrinkTests.fs
@@ -73,19 +73,19 @@ let shrinkTests = testList "Shrink tests" [
         let actual =
             Shrink.towards 0 100
             |> Seq.toList
-        [50; 75; 88; 94; 97; 99] =! actual
+        [0; 50; 75; 88; 94; 97; 99] =! actual
 
     testCase "towards correct on input 500, 1000" <| fun _ ->
         let actual =
             Shrink.towards 500 1000
             |> Seq.toList
-        [750; 875; 938; 969; 985; 993; 997; 999] =! actual
+        [500; 750; 875; 938; 969; 985; 993; 997; 999] =! actual
 
     testCase "towards correct on input -50, -26" <| fun _ ->
         let actual =
             Shrink.towards -50 -26
             |> Seq.toList
-        [-38; -32; -29; -27] =! actual
+        [-50; -38; -32; -29; -27] =! actual
 
     testCase "towards correct on input 4, 5" <| fun _ ->
         let actual =

--- a/tests/Hedgehog.Tests/ShrinkTests.fs
+++ b/tests/Hedgehog.Tests/ShrinkTests.fs
@@ -205,4 +205,79 @@ let shrinkTests = testList "Shrink tests" [
         | Failed failureData ->
             failureData.Shrinks =! shrinkLimit
         | _ -> failwith "impossible"
+
+    testCase "createTree correct for 0,0" <| fun _ ->
+        let actual = Shrink.createTree 0 0 |> Tree.map (sprintf "%A") |> Tree.render
+        let expected = "0"
+        expected =! actual
+
+    testCase "createTree correct for 0,1" <| fun _ ->
+        let actual = Shrink.createTree 0 1 |> Tree.map (sprintf "%A") |> Tree.renderList
+        let expected =
+          [ "1"
+            "└-0" ]
+        expected =! actual
+
+    testCase "createTree correct for 0,2" <| fun _ ->
+        let actual = Shrink.createTree 0 2 |> Tree.map (sprintf "%A") |> Tree.renderList
+        let expected =
+          [ "2"
+            "└-1"
+            "  └-0" ]
+        expected =! actual
+
+    testCase "createTree correct for 0,3" <| fun _ ->
+        let actual = Shrink.createTree 0 3 |> Tree.map (sprintf "%A") |> Tree.renderList
+        let expected =
+            [ "3"
+              "└-2"
+              "  └-1"
+              "    └-0" ]
+        expected =! actual
+
+    testCase "createTree correct for 0,4" <| fun _ ->
+        let actual = Shrink.createTree 0 4 |> Tree.map (sprintf "%A") |> Tree.renderList
+        let expected =
+            [ "4"
+              "├-2"
+              "| └-1"
+              "|   └-0"
+              "└-3" ]
+        expected =! actual
+
+    testCase "createTree correct for 0,5" <| fun _ ->
+        let actual = Shrink.createTree 0 5 |> Tree.map (sprintf "%A") |> Tree.renderList
+        let expected =
+            [ "5"
+              "├-3"
+              "| └-2"
+              "|   └-1"
+              "|     └-0"
+              "└-4" ]
+        expected =! actual
+
+    testCase "createTree correct for 0,6" <| fun _ ->
+        let actual = Shrink.createTree 0 6 |> Tree.map (sprintf "%A") |> Tree.renderList
+        let expected =
+            [ "6"
+              "├-3"
+              "| └-2"
+              "|   └-1"
+              "|     └-0"
+              "└-5"
+              "  └-4" ]
+        expected =! actual
+
+    testCase "createTree correct for 0,7" <| fun _ ->
+        let actual = Shrink.createTree 0 7 |> Tree.map (sprintf "%A") |> Tree.renderList
+        let expected =
+            [ "7"
+              "├-4"
+              "| ├-2"
+              "| | └-1"
+              "| |   └-0"
+              "| └-3"
+              "└-6"
+              "  └-5" ]
+        expected =! actual
 ]

--- a/tests/Hedgehog.Tests/ShrinkTests.fs
+++ b/tests/Hedgehog.Tests/ShrinkTests.fs
@@ -69,23 +69,29 @@ let shrinkTests = testList "Shrink tests" [
           [ "a"; "b"; "c" ] ]
         =! actual
 
-    testCase "towards shrinks an integral number by edging towards a destination - exmaple 1" <| fun _ ->
+    testCase "towards correct on input 0, 100" <| fun _ ->
         let actual =
             Shrink.towards 0 100
             |> Seq.toList
-        [0; 50; 75; 88; 94; 97; 99] =! actual
+        [50; 75; 88; 94; 97; 99] =! actual
 
-    testCase "towards shrinks an integral number by edging towards a destination - exmaple 2" <| fun _ ->
+    testCase "towards correct on input 500, 1000" <| fun _ ->
         let actual =
             Shrink.towards 500 1000
             |> Seq.toList
-        [500; 750; 875; 938; 969; 985; 993; 997; 999] =! actual
+        [750; 875; 938; 969; 985; 993; 997; 999] =! actual
 
-    testCase "towards shrinks an integral number by edging towards a destination - exmaple 3" <| fun _ ->
+    testCase "towards correct on input -50, -26" <| fun _ ->
         let actual =
             Shrink.towards -50 -26
             |> Seq.toList
-        [-50; -38; -32; -29; -27] =! actual
+        [-38; -32; -29; -27] =! actual
+
+    testCase "towards correct on input 4, 5" <| fun _ ->
+        let actual =
+            Shrink.towards 4 5
+            |> Seq.toList
+        [4] =! actual
 
     testCase "towardsDouble shrinks a floating-point number by edging towards a destination - example 1" <| fun _ ->
         let actual =
@@ -222,26 +228,26 @@ let shrinkTests = testList "Shrink tests" [
         let actual = Shrink.createTree 0 2 |> Tree.map (sprintf "%A") |> Tree.renderList
         let expected =
           [ "2"
-            "└-1"
-            "  └-0" ]
+            "├-0"
+            "└-1" ]
         expected =! actual
 
     testCase "createTree correct for 0,3" <| fun _ ->
         let actual = Shrink.createTree 0 3 |> Tree.map (sprintf "%A") |> Tree.renderList
         let expected =
             [ "3"
+              "├-0"
               "└-2"
-              "  └-1"
-              "    └-0" ]
+              "  └-1" ]
         expected =! actual
 
     testCase "createTree correct for 0,4" <| fun _ ->
         let actual = Shrink.createTree 0 4 |> Tree.map (sprintf "%A") |> Tree.renderList
         let expected =
             [ "4"
+              "├-0"
               "├-2"
               "| └-1"
-              "|   └-0"
               "└-3" ]
         expected =! actual
 
@@ -249,10 +255,10 @@ let shrinkTests = testList "Shrink tests" [
         let actual = Shrink.createTree 0 5 |> Tree.map (sprintf "%A") |> Tree.renderList
         let expected =
             [ "5"
+              "├-0"
               "├-3"
               "| └-2"
               "|   └-1"
-              "|     └-0"
               "└-4" ]
         expected =! actual
 
@@ -260,10 +266,10 @@ let shrinkTests = testList "Shrink tests" [
         let actual = Shrink.createTree 0 6 |> Tree.map (sprintf "%A") |> Tree.renderList
         let expected =
             [ "6"
+              "├-0"
               "├-3"
               "| └-2"
               "|   └-1"
-              "|     └-0"
               "└-5"
               "  └-4" ]
         expected =! actual
@@ -272,12 +278,25 @@ let shrinkTests = testList "Shrink tests" [
         let actual = Shrink.createTree 0 7 |> Tree.map (sprintf "%A") |> Tree.renderList
         let expected =
             [ "7"
+              "├-0"
               "├-4"
               "| ├-2"
               "| | └-1"
-              "| |   └-0"
               "| └-3"
               "└-6"
               "  └-5" ]
         expected =! actual
+
+    testCase "createTree correct for 4,5" <| fun _ ->
+        let actual = Shrink.createTree 4 5 |> Tree.map (sprintf "%A") |> Tree.renderList
+        let expected =
+            [ "5"
+              "└-4" ]
+        expected =! actual
+
+    testCase "createTree 0,n creates a tree containing each value in [0,n] exactly once" <| fun _ ->
+        for n in [0..100] do
+            let actual = Shrink.createTree 0 n |> Tree.toSeq |> Seq.sort |> Seq.toList
+            let expected = [0..n]
+            expected =! actual
 ]


### PR DESCRIPTION
Fixes #224

This PR changes the implementation of `Gen.integral` so that the shrink tree corresponds to the choices that binary search would make.

This is a draft PR because more testing is needed.  I "manually" tested it with `0` for `destination` and `4` for `x`, and the resulting tree matches my expectation, which I showed in https://github.com/hedgehogqa/fsharp-hedgehog/issues/224#issuecomment-724177320.

I don't know how to create an automated test for this.  The main problem is that calling `Gen.integral` includes randomness from the call to `Random.integral`.  If I try to extract the `createTree` function to avoid that randomness, then I get these compile errors and warning.
```
error FS1114: The value 'Hedgehog.Gen.createTree' was marked inline but was not bound in the optimization environment
error FS1113: The value 'createTree' was marked inline but its implementation makes use of an internal or private function which is not sufficiently accessible
warning FS1116: A value marked as 'inline' has an unexpected value
error FS1118: Failed to inline the value 'createTree' marked 'inline', perhaps because a recursive value was marked 'inline'
```

The impression I get is that it is not possible to define a function that is both recursive and inlined.  Is there a way to expose the `createTree` function for testing?

The code is not very pretty.  For example, I reused `Shrink.towards` but then hacked the output to fit the one case I was testing.  I wouldn't be surprised if I missed more edge cases, but I do think it is "mostly" correct.  I would prefer to create some automated unit tests before simplifying the code.

Some good news is that all existing tests still pass.