### PR TITLE
Split Property.fs across multiple files

### DIFF
--- a/src/Hedgehog/AutoOpen.fs
+++ b/src/Hedgehog/AutoOpen.fs
@@ -1,4 +1,8 @@
 ﻿[<AutoOpen>]
 module internal AutoOpen
 
-    let flip f b a = f a b
+let inline always (a : 'a) (_ : 'b) : 'a =
+    a
+
+let inline flip (f : 'a -> 'b -> 'c) (b : 'b) (a : 'a) : 'c =
+    f a b

--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -32,6 +32,10 @@ https://github.com/hedgehogqa/fsharp-hedgehog/blob/master/doc/tutorial.md
     <Compile Include="Random.fs" />
     <Compile Include="Shrink.fs" />
     <Compile Include="Gen.fs" />
+    <Compile Include="Journal.fs" />
+    <Compile Include="Tuple.fs" />
+    <Compile Include="Outcome.fs" />
+    <Compile Include="Report.fs" />
     <Compile Include="Property.fs" />
     <Compile Include="Linq\Gen.fs" />
     <Compile Include="Linq\Property.fs" />

--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -25,7 +25,6 @@ https://github.com/hedgehogqa/fsharp-hedgehog/blob/master/doc/tutorial.md
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AutoOpen.fs" />
-    <Compile Include="Util.fs" />
     <Compile Include="Numeric.fs" />
     <Compile Include="Seed.fs" />
     <Compile Include="Tree.fs" />

--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -25,6 +25,7 @@ https://github.com/hedgehogqa/fsharp-hedgehog/blob/master/doc/tutorial.md
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AutoOpen.fs" />
+    <Compile Include="Util.fs" />
     <Compile Include="Numeric.fs" />
     <Compile Include="Seed.fs" />
     <Compile Include="Tree.fs" />

--- a/src/Hedgehog/Journal.fs
+++ b/src/Hedgehog/Journal.fs
@@ -5,20 +5,31 @@ type Journal =
     | Journal of seq<unit -> string>
 
 module Journal =
-    let ofList (xs : seq<unit -> string>) : Journal =
-        Journal xs
 
-    let toList (Journal xs : Journal) : List<string> =
-        Seq.toList <| Seq.map (fun f -> f ()) xs
+    /// Creates a journal from a sequence of entries.
+    let ofSeq (entries : seq<unit -> string>) : Journal =
+        Journal entries
 
+    /// Evaluates a single entry, returning it's message.
+    let private evalEntry (f : unit -> string) : string =
+        f()
+
+    /// Evaluates all entries in the journal, returning their messages.
+    let eval (Journal entries : Journal) : seq<string> =
+        Seq.map evalEntry entries
+
+    /// Represents a journal with no entries.
     let empty : Journal =
-        Seq.empty |> ofList
+        ofSeq []
 
-    let singleton (x : string) : Journal =
-        Seq.singleton (fun () -> x) |> ofList
+    /// Creates a single entry journal from a given message.
+    let singletonMessage (message : string) : Journal =
+        ofSeq [ fun () -> message ]
 
-    let delayedSingleton (x : unit -> string) : Journal =
-        Seq.singleton x |> ofList
+    /// Creates a single entry journal from a given entry.
+    let singleton (entry : unit -> string) : Journal =
+        ofSeq [ entry ]
 
+    /// Creates a journal composed of entries from two journals.
     let append (Journal xs) (Journal ys) : Journal =
-        Seq.append xs ys |> ofList
+        ofSeq <| Seq.append xs ys

--- a/src/Hedgehog/Journal.fs
+++ b/src/Hedgehog/Journal.fs
@@ -1,0 +1,24 @@
+namespace Hedgehog
+
+[<Struct>]
+type Journal =
+    | Journal of seq<unit -> string>
+
+module Journal =
+    let ofList (xs : seq<unit -> string>) : Journal =
+        Journal xs
+
+    let toList (Journal xs : Journal) : List<string> =
+        Seq.toList <| Seq.map (fun f -> f ()) xs
+
+    let empty : Journal =
+        Seq.empty |> ofList
+
+    let singleton (x : string) : Journal =
+        Seq.singleton (fun () -> x) |> ofList
+
+    let delayedSingleton (x : unit -> string) : Journal =
+        Seq.singleton x |> ofList
+
+    let append (Journal xs) (Journal ys) : Journal =
+        Seq.append xs ys |> ofList

--- a/src/Hedgehog/Journal.fs
+++ b/src/Hedgehog/Journal.fs
@@ -32,4 +32,5 @@ module Journal =
 
     /// Creates a journal composed of entries from two journals.
     let append (Journal xs) (Journal ys) : Journal =
-        ofSeq <| Seq.append xs ys
+        Seq.append xs ys
+        |> ofSeq

--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -23,11 +23,11 @@ type Property = private Property of Property<unit> with
         Property.ofBool value
         |> Property
 
-    static member FromGen (gen : Gen<Journal * Result<'T>>) : Property<'T> =
+    static member FromGen (gen : Gen<Journal * Outcome<'T>>) : Property<'T> =
         Property.ofGen gen
 
-    static member FromResult (result : Result<'T>) : Property<'T> =
-        Property.ofResult result
+    static member FromOutcome (result : Outcome<'T>) : Property<'T> =
+        Property.ofOutcome result
 
     static member FromThrowing (throwingFunc : Action<'T>, arg : 'T) : Property =
         Property.ofThrowing throwingFunc.Invoke arg
@@ -54,7 +54,7 @@ type Property = private Property of Property<unit> with
 type PropertyExtensions private () =
 
     [<Extension>]
-    static member ToGen (property : Property<'T>) : Gen<Journal * Result<'T>> =
+    static member ToGen (property : Property<'T>) : Gen<Journal * Outcome<'T>> =
         Property.toGen property
 
     [<Extension>]

--- a/src/Hedgehog/Outcome.fs
+++ b/src/Hedgehog/Outcome.fs
@@ -19,9 +19,9 @@ module Outcome =
     [<CompiledName("Map")>]
     let map (f : 'a -> 'b) (result : Outcome<'a>) : Outcome<'b> =
         cata result
-            <| always Failure
-            <| always Discard
-            <| (f >> Success)
+            (always Failure)
+            (always Discard)
+            (f >> Success)
 
     [<CompiledName("Filter")>]
     let filter (f : 'a -> bool) (result : Outcome<'a>) : Outcome<'a> =
@@ -32,13 +32,13 @@ module Outcome =
                 Discard
 
         cata result
-            <| always Failure
-            <| always Discard
-            <| successOrDiscard
+            (always Failure)
+            (always Discard)
+            successOrDiscard
 
     [<CompiledName("IsFailure")>]
     let isFailure (result : Outcome<'a>) : bool =
         cata result
-            <| always true
-            <| always false
-            <| always false
+            (always true)
+            (always false)
+            (always false)

--- a/src/Hedgehog/Outcome.fs
+++ b/src/Hedgehog/Outcome.fs
@@ -1,0 +1,40 @@
+namespace Hedgehog
+
+type Outcome<'a> =
+    | Failure
+    | Discard
+    | Success of 'a
+
+module Outcome =
+    [<CompiledName("Map")>]
+    let map (f : 'a -> 'b) (result : Outcome<'a>) : Outcome<'b> =
+        match result with
+        | Failure ->
+            Failure
+        | Discard ->
+            Discard
+        | Success x ->
+            Success (f x)
+
+    [<CompiledName("Filter")>]
+    let filter (f : 'a -> bool) (result : Outcome<'a>) : Outcome<'a> =
+        match result with
+        | Failure ->
+            Failure
+        | Discard ->
+            Discard
+        | Success x ->
+            if f x then
+              Success x
+            else
+              Discard
+
+    [<CompiledName("IsFailure")>]
+    let isFailure (result : Outcome<'a>) : bool =
+        match result with
+        | Failure ->
+            true
+        | Discard ->
+            false
+        | Success _ ->
+            false

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -56,7 +56,7 @@ module Property =
             failure
 
     let counterexample (msg : unit -> string) : Property<unit> =
-        Gen.constant (Journal.delayedSingleton msg, Success ()) |> ofGen
+        Gen.constant (Journal.singleton msg, Success ()) |> ofGen
 
     let private mapGen
             (f : Gen<Journal * Outcome<'a>> -> Gen<Journal * Outcome<'b>>)
@@ -83,7 +83,7 @@ module Property =
 
     let forAll (gen : Gen<'a>) (k : 'a -> Property<'b>) : Property<'b> =
         let handle (e : exn) =
-            Gen.constant (Journal.singleton (string e), Failure) |> ofGen
+            Gen.constant (Journal.singletonMessage (string e), Failure) |> ofGen
         let prepend (x : 'a) =
             bind (counterexample (fun () -> sprintf "%A" x)) (fun _ -> try k x with e -> handle e) |> toGen
         Gen.bind gen prepend |> ofGen

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -3,223 +3,15 @@
 open System
 
 [<Struct>]
-type Journal =
-    | Journal of seq<unit -> string>
-
-type Result<'a> =
-    | Failure
-    | Discard
-    | Success of 'a
-
-[<Struct>]
 type Property<'a> =
-    | Property of Gen<Journal * Result<'a>>
-
-[<Measure>] type tests
-[<Measure>] type discards
-[<Measure>] type shrinks
-
-type FailureReport = {
-    Size : Size
-    Seed : Seed
-    Shrinks : int<shrinks>
-    Journal : Journal
-    RenderRecheck : bool
-}
-
-type Status =
-    | Failed of FailureReport
-    | GaveUp
-    | OK
-
-type Report = {
-    Tests : int<tests>
-    Discards : int<discards>
-    Status : Status
-}
-
-[<AutoOpen>]
-module private Tuple =
-    let first (f : 'a -> 'c) (x : 'a, y : 'b) : 'c * 'b =
-        f x, y
-
-    let second (f : 'b -> 'c) (x : 'a, y : 'b) : 'a * 'c =
-        x, f y
-
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
-module Journal =
-    let ofList (xs : seq<unit -> string>) : Journal =
-        Journal xs
-
-    let toList (Journal xs : Journal) : List<string> =
-        xs
-        |> Seq.map (fun f -> f ())
-        |> Seq.toList
-
-    let empty : Journal =
-        Seq.empty |> ofList
-
-    let singleton (x : string) : Journal =
-        Seq.singleton (fun () -> x) |> ofList
-
-    let delayedSingleton (x : unit -> string) : Journal =
-        Seq.singleton x |> ofList
-
-    let append (Journal xs) (Journal ys) : Journal =
-        Seq.append xs ys |> ofList
-
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
-module Result =
-    [<CompiledName("Map")>]
-    let map (f : 'a -> 'b) (r : Result<'a>) : Result<'b> =
-        match r with
-        | Failure ->
-            Failure
-        | Discard ->
-            Discard
-        | Success x ->
-            Success (f x)
-
-    [<CompiledName("Filter")>]
-    let filter (f : 'a -> bool) (r : Result<'a>) : Result<'a> =
-        match r with
-        | Failure ->
-            Failure
-        | Discard ->
-            Discard
-        | Success x ->
-            if f x then
-              Success x
-            else
-              Discard
-
-    [<CompiledName("IsFailure")>]
-    let isFailure (x : Result<'a>) : bool =
-        match x with
-        | Failure ->
-            true
-        | Discard ->
-            false
-        | Success _ ->
-            false
-
-[<AutoOpen>]
-module private Pretty =
-    open System.Text
-
-    let private renderTests : int<tests> -> string = function
-        | 1<tests> ->
-            "1 test"
-        | n ->
-            sprintf "%d tests" n
-
-    let private renderDiscards : int<discards> -> string = function
-        | 1<discards> ->
-            "1 discard"
-        | n ->
-            sprintf "%d discards" n
-
-    let private renderAndDiscards : int<discards> -> string = function
-        | 0<discards> ->
-            ""
-        | 1<discards> ->
-            " and 1 discard"
-        | n ->
-            sprintf " and %d discards" n
-
-    let private renderAndShrinks : int<shrinks> -> string = function
-        | 0<shrinks> ->
-            ""
-        | 1<shrinks> ->
-            " and 1 shrink"
-        | n ->
-            sprintf " and %d shrinks" n
-
-    let private append (sb : StringBuilder) (msg : string) : unit =
-        sb.AppendLine msg |> ignore
-
-    let private renderf (sb : StringBuilder) (fmt : Printf.StringFormat<'a, unit>) : 'a =
-        Printf.ksprintf (sb.AppendLine >> ignore) fmt
-
-    let renderOK (report : Report) : string =
-        sprintf "+++ OK, passed %s." (renderTests report.Tests)
-
-    let renderGaveUp (report : Report) : string =
-        sprintf "*** Gave up after %s, passed %s."
-            (renderDiscards report.Discards)
-            (renderTests report.Tests)
-
-    let renderFailed (failure : FailureReport) (report : Report) : string =
-        let sb = StringBuilder ()
-
-        renderf sb "*** Failed! Falsifiable (after %s%s%s):"
-            (renderTests report.Tests)
-            (renderAndShrinks failure.Shrinks)
-            (renderAndDiscards report.Discards)
-
-        List.iter (append sb) (Journal.toList failure.Journal)
-
-        if failure.RenderRecheck then
-            renderf sb "This failure can be reproduced by running:"
-            renderf sb "> Property.recheck (%d : Size) ({ Value = %A; Gamma = %A }) <property>"
-                failure.Size
-                failure.Seed.Value
-                failure.Seed.Gamma
-
-        sb.ToString (0, sb.Length - 1) // Exclude extra newline.
-
-[<AbstractClass>]
-type HedgehogException (message : string) =
-    inherit Exception (message)
-
-type GaveUpException (report : Report) =
-    inherit HedgehogException (renderGaveUp report)
-
-    member __.Tests =
-        report.Tests
-
-type FailedException (failure : FailureReport, report : Report) =
-    inherit HedgehogException (renderFailed failure report)
-
-    member __.Tests =
-        report.Tests
-
-    member __.Discards =
-        report.Discards
-
-    member __.Shrinks =
-        failure.Shrinks
-
-    member __.Journal =
-        failure.Journal
-
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
-module Report =
-
-    let render (report : Report) : string =
-        match report.Status with
-        | OK ->
-            renderOK report
-        | GaveUp ->
-            renderGaveUp report
-        | Failed failure ->
-            renderFailed failure report
-
-    let tryRaise (report : Report) : unit =
-        match report.Status with
-        | OK ->
-            ()
-        | GaveUp ->
-            raise (GaveUpException (report))
-        | Failed failure  ->
-            raise (FailedException (failure, report))
+    | Property of Gen<Journal * Outcome<'a>>
 
 module Property =
 
-    let ofGen (x : Gen<Journal * Result<'a>>) : Property<'a> =
+    let ofGen (x : Gen<Journal * Outcome<'a>>) : Property<'a> =
         Property x
 
-    let toGen (Property x : Property<'a>) : Gen<Journal * Result<'a>> =
+    let toGen (Property x : Property<'a>) : Gen<Journal * Outcome<'a>> =
         x
 
     let tryFinally (m : Property<'a>) (after : unit -> unit) : Property<'a> =
@@ -243,21 +35,19 @@ module Property =
                 x.Dispose ())
 
     let filter (p : 'a -> bool) (m : Property<'a>) : Property<'a> =
-        toGen m
-        |> Gen.map (second (Result.filter p))
-        |> ofGen
+        Gen.map (Tuple.mapSecond <| Outcome.filter p) (toGen m) |> ofGen
 
-    let ofResult (x : Result<'a>) : Property<'a> =
+    let ofOutcome (x : Outcome<'a>) : Property<'a> =
         (Journal.empty, x) |> Gen.constant |> ofGen
 
     let failure : Property<unit> =
-        Failure |> ofResult
+        Failure |> ofOutcome
 
     let discard : Property<unit> =
-        Discard |> ofResult
+        Discard |> ofOutcome
 
     let success (x : 'a) : Property<'a> =
-        Success x |> ofResult
+        Success x |> ofOutcome
 
     let ofBool (x : bool) : Property<unit> =
         if x then
@@ -269,24 +59,24 @@ module Property =
         Gen.constant (Journal.delayedSingleton msg, Success ()) |> ofGen
 
     let private mapGen
-            (f : Gen<Journal * Result<'a>> -> Gen<Journal * Result<'b>>)
+            (f : Gen<Journal * Outcome<'a>> -> Gen<Journal * Outcome<'b>>)
             (x : Property<'a>) : Property<'b> =
         toGen x |> f |> ofGen
 
     let map (f : 'a -> 'b) (x : Property<'a>) : Property<'b> =
-        (mapGen << Gen.map << second << Result.map) f x
+        (mapGen << Gen.map << Tuple.mapSecond << Outcome.map) f x
 
     let private bindGen
-            (m : Gen<Journal * Result<'a>>)
-            (k : 'a -> Gen<Journal * Result<'b>>) : Gen<Journal * Result<'b>> =
-        Gen.bind m (fun (journal, result) ->
+            (m : Gen<Journal * Outcome<'a>>)
+            (k : 'a -> Gen<Journal * Outcome<'b>>) : Gen<Journal * Outcome<'b>> =
+        Gen.bind m <| fun (journal, result) ->
             match result with
             | Failure ->
                 Gen.constant (journal, Failure)
             | Discard ->
                 Gen.constant (journal, Discard)
             | Success x ->
-                Gen.map (first (Journal.append journal)) (k x))
+                Gen.map (Tuple.mapFirst (Journal.append journal)) (k x)
 
     let bind (m : Property<'a>) (k : 'a -> Property<'b>) : Property<'b> =
         bindGen (toGen m) (toGen << k) |> ofGen
@@ -309,11 +99,11 @@ module Property =
             (renderRecheck : bool)
             (size : Size)
             (seed : Seed)
-            (Node ((journal, x), xs) : Tree<Journal * Result<'a>>)
+            (Node ((journal, x), xs) : Tree<Journal * Outcome<'a>>)
             (nshrinks : int<shrinks>) : Status =
         match x with
         | Failure ->
-            match Seq.tryFind (Result.isFailure << snd << Tree.outcome) xs with
+            match Seq.tryFind (Outcome.isFailure << snd << Tree.outcome) xs with
             | None ->
                 Failed { Size = size; Seed = seed; Shrinks = nshrinks; Journal = journal; RenderRecheck = renderRecheck }
             | Some tree ->

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -35,7 +35,7 @@ module Property =
                 x.Dispose ())
 
     let filter (p : 'a -> bool) (m : Property<'a>) : Property<'a> =
-        Gen.map (Tuple.mapSecond <| Outcome.filter p) (toGen m) |> ofGen
+        GenTuple.mapSecond (Outcome.filter p) (toGen m) |> ofGen
 
     let ofOutcome (x : Outcome<'a>) : Property<'a> =
         (Journal.empty, x) |> Gen.constant |> ofGen
@@ -64,7 +64,7 @@ module Property =
         toGen x |> f |> ofGen
 
     let map (f : 'a -> 'b) (x : Property<'a>) : Property<'b> =
-        (mapGen << Gen.map << Tuple.mapSecond << Outcome.map) f x
+        (mapGen << GenTuple.mapSecond << Outcome.map) f x
 
     let private bindGen
             (m : Gen<Journal * Outcome<'a>>)
@@ -76,7 +76,7 @@ module Property =
             | Discard ->
                 Gen.constant (journal, Discard)
             | Success x ->
-                Gen.map (Tuple.mapFirst (Journal.append journal)) (k x)
+                GenTuple.mapFirst (Journal.append journal) (k x)
 
     let bind (m : Property<'a>) (k : 'a -> Property<'b>) : Property<'b> =
         bindGen (toGen m) (toGen << k) |> ofGen

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -35,7 +35,7 @@ module Property =
                 x.Dispose ())
 
     let filter (p : 'a -> bool) (m : Property<'a>) : Property<'a> =
-        GenTuple.mapSecond (Outcome.filter p) (toGen m) |> ofGen
+        GenTuple.mapSnd (Outcome.filter p) (toGen m) |> ofGen
 
     let ofOutcome (x : Outcome<'a>) : Property<'a> =
         (Journal.empty, x) |> Gen.constant |> ofGen
@@ -64,7 +64,7 @@ module Property =
         toGen x |> f |> ofGen
 
     let map (f : 'a -> 'b) (x : Property<'a>) : Property<'b> =
-        (mapGen << GenTuple.mapSecond << Outcome.map) f x
+        (mapGen << GenTuple.mapSnd << Outcome.map) f x
 
     let private bindGen
             (m : Gen<Journal * Outcome<'a>>)
@@ -76,7 +76,7 @@ module Property =
             | Discard ->
                 Gen.constant (journal, Discard)
             | Success x ->
-                GenTuple.mapFirst (Journal.append journal) (k x)
+                GenTuple.mapFst (Journal.append journal) (k x)
 
     let bind (m : Property<'a>) (k : 'a -> Property<'b>) : Property<'b> =
         bindGen (toGen m) (toGen << k) |> ofGen

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -69,14 +69,14 @@ module Property =
     let private bindGen
             (m : Gen<Journal * Outcome<'a>>)
             (k : 'a -> Gen<Journal * Outcome<'b>>) : Gen<Journal * Outcome<'b>> =
-        Gen.bind m <| fun (journal, result) ->
+        Gen.bind m (fun (journal, result) ->
             match result with
             | Failure ->
                 Gen.constant (journal, Failure)
             | Discard ->
                 Gen.constant (journal, Discard)
             | Success x ->
-                GenTuple.mapFst (Journal.append journal) (k x)
+                GenTuple.mapFst (Journal.append journal) (k x))
 
     let bind (m : Property<'a>) (k : 'a -> Property<'b>) : Property<'b> =
         bindGen (toGen m) (toGen << k) |> ofGen

--- a/src/Hedgehog/Report.fs
+++ b/src/Hedgehog/Report.fs
@@ -24,6 +24,7 @@ type Report = {
 }
 
 module Report =
+
     open System
     open System.Text
 
@@ -55,11 +56,11 @@ module Report =
         | n ->
             sprintf " and %d shrinks" n
 
-    let private append (sb : StringBuilder) (msg : string) : unit =
+    let private appendLine (sb : StringBuilder) (msg : string) : unit =
         sb.AppendLine msg |> ignore
 
-    let private renderf (sb : StringBuilder) (fmt : Printf.StringFormat<'a, unit>) : 'a =
-        Printf.ksprintf (append sb) fmt
+    let private appendLinef (sb : StringBuilder) (fmt : Printf.StringFormat<'a, unit>) : 'a =
+        Printf.ksprintf (appendLine sb) fmt
 
     let private renderOK (report : Report) : string =
         sprintf "+++ OK, passed %s." (renderTests report.Tests)
@@ -72,16 +73,16 @@ module Report =
     let private renderFailed (failure : FailureData) (report : Report) : string =
         let sb = StringBuilder ()
 
-        renderf sb "*** Failed! Falsifiable (after %s%s%s):"
+        appendLinef sb "*** Failed! Falsifiable (after %s%s%s):"
             (renderTests report.Tests)
             (renderAndShrinks failure.Shrinks)
             (renderAndDiscards report.Discards)
 
-        Seq.iter (append sb) (Journal.eval failure.Journal)
+        Seq.iter (appendLine sb) (Journal.eval failure.Journal)
 
         if failure.RenderRecheck then
-            renderf sb "This failure can be reproduced by running:"
-            renderf sb "> Property.recheck (%d : Size) ({ Value = %A; Gamma = %A }) <property>"
+            appendLinef sb "This failure can be reproduced by running:"
+            appendLinef sb "> Property.recheck (%d : Size) ({ Value = %A; Gamma = %A }) <property>"
                 failure.Size
                 failure.Seed.Value
                 failure.Seed.Gamma

--- a/src/Hedgehog/Report.fs
+++ b/src/Hedgehog/Report.fs
@@ -104,4 +104,4 @@ module Report =
             ()
         | GaveUp
         | Failed _ ->
-            raise <| Exception(render report)
+            raise (Exception(render report))

--- a/src/Hedgehog/Report.fs
+++ b/src/Hedgehog/Report.fs
@@ -1,0 +1,106 @@
+namespace Hedgehog
+
+[<Measure>] type tests
+[<Measure>] type discards
+[<Measure>] type shrinks
+
+type FailureData = {
+    Size : Size
+    Seed : Seed
+    Shrinks : int<shrinks>
+    Journal : Journal
+    RenderRecheck : bool
+}
+
+type Status =
+    | Failed of FailureData
+    | GaveUp
+    | OK
+
+type Report = {
+    Tests : int<tests>
+    Discards : int<discards>
+    Status : Status
+}
+
+module Report =
+    open System
+    open System.Text
+
+    let private renderTests : int<tests> -> string = function
+        | 1<tests> ->
+            "1 test"
+        | n ->
+            sprintf "%d tests" n
+
+    let private renderDiscards : int<discards> -> string = function
+        | 1<discards> ->
+            "1 discard"
+        | n ->
+            sprintf "%d discards" n
+
+    let private renderAndDiscards : int<discards> -> string = function
+        | 0<discards> ->
+            ""
+        | 1<discards> ->
+            " and 1 discard"
+        | n ->
+            sprintf " and %d discards" n
+
+    let private renderAndShrinks : int<shrinks> -> string = function
+        | 0<shrinks> ->
+            ""
+        | 1<shrinks> ->
+            " and 1 shrink"
+        | n ->
+            sprintf " and %d shrinks" n
+
+    let private append (sb : StringBuilder) (msg : string) : unit =
+        sb.AppendLine msg |> ignore
+
+    let private renderf (sb : StringBuilder) (fmt : Printf.StringFormat<'a, unit>) : 'a =
+        Printf.ksprintf (append sb) fmt
+
+    let private renderOK (report : Report) : string =
+        sprintf "+++ OK, passed %s." (renderTests report.Tests)
+
+    let private renderGaveUp (report : Report) : string =
+        sprintf "*** Gave up after %s, passed %s."
+            (renderDiscards report.Discards)
+            (renderTests report.Tests)
+
+    let private renderFailed (failure : FailureData) (report : Report) : string =
+        let sb = StringBuilder ()
+
+        renderf sb "*** Failed! Falsifiable (after %s%s%s):"
+            (renderTests report.Tests)
+            (renderAndShrinks failure.Shrinks)
+            (renderAndDiscards report.Discards)
+
+        List.iter (append sb) (Journal.toList failure.Journal)
+
+        if failure.RenderRecheck then
+            renderf sb "This failure can be reproduced by running:"
+            renderf sb "> Property.recheck (%d : Size) ({ Value = %A; Gamma = %A }) <property>"
+                failure.Size
+                failure.Seed.Value
+                failure.Seed.Gamma
+
+        sb.ToString (0, sb.Length - 1) // Exclude extra newline.
+
+    let render (report : Report) : string =
+        match report.Status with
+        | OK ->
+            renderOK report
+        | GaveUp ->
+            renderGaveUp report
+        | Failed failure ->
+            renderFailed failure report
+
+    let tryRaise (report : Report) : unit =
+        match report.Status with
+        | OK ->
+            ()
+        | GaveUp
+        | Failed _ ->
+            raise <| Exception(render report)

--- a/src/Hedgehog/Report.fs
+++ b/src/Hedgehog/Report.fs
@@ -77,7 +77,7 @@ module Report =
             (renderAndShrinks failure.Shrinks)
             (renderAndDiscards report.Discards)
 
-        List.iter (append sb) (Journal.toList failure.Journal)
+        Seq.iter (append sb) (Journal.eval failure.Journal)
 
         if failure.RenderRecheck then
             renderf sb "This failure can be reproduced by running:"

--- a/src/Hedgehog/Script.fsx
+++ b/src/Hedgehog/Script.fsx
@@ -1,11 +1,16 @@
 ﻿#if INTERACTIVE
-#load "Numeric.fs"
+#load "AutoOpen.fs"
+      "Numeric.fs"
       "Seed.fs"
       "Tree.fs"
       "Range.fs"
       "Random.fs"
       "Shrink.fs"
       "Gen.fs"
+      "Journal.fs"
+      "Tuple.fs"
+      "Outcome.fs"
+      "Report.fs"
       "Property.fs"
 #endif
 

--- a/src/Hedgehog/Shrink.fs
+++ b/src/Hedgehog/Shrink.fs
@@ -1,7 +1,5 @@
 ﻿namespace Hedgehog
 
-open System
-
 module Seq =
     let cons (x : 'a) (xs : seq<'a>) : seq<'a> =
         seq {

--- a/src/Hedgehog/Tuple.fs
+++ b/src/Hedgehog/Tuple.fs
@@ -2,18 +2,18 @@ namespace Hedgehog
 
 module private Tuple =
 
-    let mapFirst (f : 'a -> 'c) (x : 'a, y : 'b) : 'c * 'b =
+    let mapFst (f : 'a -> 'c) (x : 'a, y : 'b) : 'c * 'b =
         f x, y
 
-    let mapSecond (f : 'b -> 'c) (x : 'a, y : 'b) : 'a * 'c =
+    let mapSnd (f : 'b -> 'c) (x : 'a, y : 'b) : 'a * 'c =
         x, f y
 
 
 module private GenTuple =
 
-    let mapFirst (f : 'a -> 'c) (gen : Gen<'a * 'b>) : Gen<'c * 'b> =
-        Gen.map (Tuple.mapFirst f) gen
+    let mapFst (f : 'a -> 'c) (gen : Gen<'a * 'b>) : Gen<'c * 'b> =
+        Gen.map (Tuple.mapFst f) gen
 
 
-    let mapSecond (f : 'b -> 'c) (gen : Gen<'a * 'b>) : Gen<'a * 'c> =
-        Gen.map (Tuple.mapSecond f) gen
+    let mapSnd (f : 'b -> 'c) (gen : Gen<'a * 'b>) : Gen<'a * 'c> =
+        Gen.map (Tuple.mapSnd f) gen

--- a/src/Hedgehog/Tuple.fs
+++ b/src/Hedgehog/Tuple.fs
@@ -1,7 +1,19 @@
-module private Hedgehog.Tuple
+namespace Hedgehog
 
-let mapFirst (f : 'a -> 'c) (x : 'a, y : 'b) : 'c * 'b =
-    f x, y
+module private Tuple =
 
-let mapSecond (f : 'b -> 'c) (x : 'a, y : 'b) : 'a * 'c =
-    x, f y
+    let mapFirst (f : 'a -> 'c) (x : 'a, y : 'b) : 'c * 'b =
+        f x, y
+
+    let mapSecond (f : 'b -> 'c) (x : 'a, y : 'b) : 'a * 'c =
+        x, f y
+
+
+module private GenTuple =
+
+    let mapFirst (f : 'a -> 'c) (gen : Gen<'a * 'b>) : Gen<'c * 'b> =
+        Gen.map (Tuple.mapFirst f) gen
+
+
+    let mapSecond (f : 'b -> 'c) (gen : Gen<'a * 'b>) : Gen<'a * 'c> =
+        Gen.map (Tuple.mapSecond f) gen

--- a/src/Hedgehog/Tuple.fs
+++ b/src/Hedgehog/Tuple.fs
@@ -1,0 +1,7 @@
+module private Hedgehog.Tuple
+
+let mapFirst (f : 'a -> 'c) (x : 'a, y : 'b) : 'c * 'b =
+    f x, y
+
+let mapSecond (f : 'b -> 'c) (x : 'a, y : 'b) : 'a * 'c =
+    x, f y

--- a/src/Hedgehog/Util.fs
+++ b/src/Hedgehog/Util.fs
@@ -1,5 +1,0 @@
-[<AutoOpen>]
-module private Hedgehog.Util
-
-let inline always (a : 'a) (_ : 'b) : 'a =
-    a

--- a/src/Hedgehog/Util.fs
+++ b/src/Hedgehog/Util.fs
@@ -1,0 +1,5 @@
+[<AutoOpen>]
+module private Hedgehog.Util
+
+let inline always (a : 'a) (_ : 'b) : 'a =
+    a


### PR DESCRIPTION
Fixes #246.

Also, while I moved `Result<'a>` I opted to rename it to `Outcome<'a>`, therefor this also fixes #181.