### PR TITLE
Improve and extend DateTime/DateTimeOffset generation

### DIFF
--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -537,7 +537,7 @@ module Gen =
               min 
                 (14L * 60L)
                 ((ticks - DateTimeOffset.MinValue.Ticks) / TimeSpan.TicksPerMinute)
-            let! offsetMinutes = int (Range.exponentialFrom 0 (Operators.int minOffsetMinutes) (Operators.int maxOffsetMinutes))
+            let! offsetMinutes = int (Range.linearFrom 0 (Operators.int minOffsetMinutes) (Operators.int maxOffsetMinutes))
             return System.DateTimeOffset(ticks, TimeSpan.FromMinutes (Operators.float offsetMinutes))
         }
 

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -516,6 +516,11 @@ module Gen =
     }
 
     /// Generates a random DateTime using the specified range.
+    /// For example:
+    ///   let range =
+    ///      Range.constantFrom
+    ///          (System.DateTime (2000, 1, 1)) System.DateTime.MinValue System.DateTime.MaxValue
+    ///   Gen.dateTime range
     [<CompiledName("DateTime")>]
     let dateTime (range : Range<DateTime>) : Gen<System.DateTime> =
         gen {

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -530,6 +530,24 @@ module Gen =
             return System.DateTime ticks
         }
 
+    /// Generates a random DateTimeOffset.
+    [<CompiledName("DateTimeOffset")>]
+    let dateTimeOffset : Gen<System.DateTimeOffset> =
+        let minTicks =
+            System.DateTimeOffset.MinValue.Ticks
+        let maxTicks =
+            System.DateTimeOffset.MaxValue.Ticks
+        gen {
+            let! ticks =
+                Range.constantFrom
+                    (System.DateTimeOffset (2000, 1, 1, 0, 0, 0, TimeSpan.Zero)).Ticks minTicks maxTicks
+                |> integral
+            let minOffsetMinutes = max (-14 * 60) (Operators.int ((maxTicks - ticks) / TimeSpan.TicksPerMinute) * -1)
+            let maxOffsetMinutes = min (14 * 60) (Operators.int ((ticks - minTicks) / TimeSpan.TicksPerMinute))
+            let! offsetMinutes = int (Range.exponentialFrom 0 minOffsetMinutes maxOffsetMinutes)
+            return System.DateTimeOffset(ticks, TimeSpan.FromMinutes (Operators.float offsetMinutes))
+        }
+
     //
     // Sampling
     //

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -515,7 +515,7 @@ module Gen =
         return System.Guid bs
     }
 
-    /// Generates a random instant in time expressed as a date and time of day.
+    /// Generates a random DateTime.
     [<CompiledName("DateTime")>]
     let dateTime : Gen<System.DateTime> =
         let minTicks =

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -515,6 +515,34 @@ module Gen =
         return System.Guid bs
     }
 
+    /// Generates a random DateTime using the specified range.
+    [<CompiledName("DateTimeRanged")>]
+    let dateTimeRanged (range : Range<DateTime>) : Gen<System.DateTime> =
+        let minTicks =
+            System.DateTime.MinValue.Ticks
+        let maxTicks =
+            System.DateTime.MaxValue.Ticks
+        gen {
+            let! ticks = range |> Range.map (fun dt -> dt.Ticks) |> integral
+            return System.DateTime ticks
+        }
+
+    /// Generates a random DateTimeOffset using the specified range.
+    [<CompiledName("DateTimeOffsetRanged")>]
+    let dateTimeOffsetRanged (range : Range<DateTimeOffset>) : Gen<System.DateTimeOffset> =
+        let minTicks =
+            System.DateTimeOffset.MinValue.Ticks
+        let maxTicks =
+            System.DateTimeOffset.MaxValue.Ticks
+        gen {
+            let! ticks = range |> Range.map (fun dt -> dt.Ticks) |> integral
+            // Ensure there is no overflow near the edges when adding the offset
+            let minOffsetMinutes = max (-14 * 60) (Operators.int ((maxTicks - ticks) / TimeSpan.TicksPerMinute) * -1)
+            let maxOffsetMinutes = min (14 * 60) (Operators.int ((ticks - minTicks) / TimeSpan.TicksPerMinute))
+            let! offsetMinutes = int (Range.exponentialFrom 0 minOffsetMinutes maxOffsetMinutes)
+            return System.DateTimeOffset(ticks, TimeSpan.FromMinutes (Operators.float offsetMinutes))
+        }
+
     /// Generates a random DateTime.
     [<CompiledName("DateTime")>]
     let dateTime : Gen<System.DateTime> =

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -516,16 +516,16 @@ module Gen =
     }
 
     /// Generates a random DateTime using the specified range.
-    [<CompiledName("DateTimeRanged")>]
-    let dateTimeRanged (range : Range<DateTime>) : Gen<System.DateTime> =
+    [<CompiledName("DateTime")>]
+    let dateTime (range : Range<DateTime>) : Gen<System.DateTime> =
         gen {
             let! ticks = range |> Range.map (fun dt -> dt.Ticks) |> integral
             return System.DateTime ticks
         }
 
     /// Generates a random DateTimeOffset using the specified range.
-    [<CompiledName("DateTimeOffsetRanged")>]
-    let dateTimeOffsetRanged (range : Range<DateTimeOffset>) : Gen<System.DateTimeOffset> =
+    [<CompiledName("DateTimeOffset")>]
+    let dateTimeOffset (range : Range<DateTimeOffset>) : Gen<System.DateTimeOffset> =
         gen {
             let! ticks = range |> Range.map (fun dt -> dt.Ticks) |> integral
             // Ensure there is no overflow near the edges when adding the offset
@@ -540,17 +540,6 @@ module Gen =
             let! offsetMinutes = int (Range.linearFrom 0 (Operators.int minOffsetMinutes) (Operators.int maxOffsetMinutes))
             return System.DateTimeOffset(ticks, TimeSpan.FromMinutes (Operators.float offsetMinutes))
         }
-
-    /// Generates a random DateTime.
-    [<CompiledName("DateTime")>]
-    let dateTime : Gen<System.DateTime> =
-        dateTimeRanged (Range.constantFrom (DateTime (2000, 1, 1)) DateTime.MinValue DateTime.MaxValue)
-
-    /// Generates a random DateTimeOffset.
-    [<CompiledName("DateTimeOffset")>]
-    let dateTimeOffset : Gen<System.DateTimeOffset> =
-        dateTimeOffsetRanged (Range.constantFrom (DateTimeOffset (2000, 1, 1, 0, 0, 0, TimeSpan.Zero)) DateTimeOffset.MinValue DateTimeOffset.MaxValue)
-
 
     //
     // Sampling

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -529,15 +529,15 @@ module Gen =
         gen {
             let! ticks = range |> Range.map (fun dt -> dt.Ticks) |> integral
             // Ensure there is no overflow near the edges when adding the offset
-            let minOffsetMinutes = 
+            let minOffsetMinutes =
               max 
-                (-14 * 60) 
-                (Operators.int ((DateTimeOffset.MaxValue.Ticks - ticks) / TimeSpan.TicksPerMinute) * -1)
-            let maxOffsetMinutes = 
+                (-14L * 60L)
+                ((DateTimeOffset.MaxValue.Ticks - ticks) / TimeSpan.TicksPerMinute * -1L)
+            let maxOffsetMinutes =
               min 
-                (14 * 60) 
-                (Operators.int ((ticks - DateTimeOffset.MinValue.Ticks) / TimeSpan.TicksPerMinute))
-            let! offsetMinutes = int (Range.exponentialFrom 0 minOffsetMinutes maxOffsetMinutes)
+                (14L * 60L)
+                ((ticks - DateTimeOffset.MinValue.Ticks) / TimeSpan.TicksPerMinute)
+            let! offsetMinutes = int (Range.exponentialFrom 0 (Operators.int minOffsetMinutes) (Operators.int maxOffsetMinutes))
             return System.DateTimeOffset(ticks, TimeSpan.FromMinutes (Operators.float offsetMinutes))
         }
 

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -546,35 +546,13 @@ module Gen =
     /// Generates a random DateTime.
     [<CompiledName("DateTime")>]
     let dateTime : Gen<System.DateTime> =
-        let minTicks =
-            System.DateTime.MinValue.Ticks
-        let maxTicks =
-            System.DateTime.MaxValue.Ticks
-        gen {
-            let! ticks =
-                Range.constantFrom
-                    (System.DateTime (2000, 1, 1)).Ticks minTicks maxTicks
-                |> integral
-            return System.DateTime ticks
-        }
+        dateTimeRanged (Range.constantFrom (DateTime (2000, 1, 1)) DateTime.MinValue DateTime.MaxValue)
 
     /// Generates a random DateTimeOffset.
     [<CompiledName("DateTimeOffset")>]
     let dateTimeOffset : Gen<System.DateTimeOffset> =
-        let minTicks =
-            System.DateTimeOffset.MinValue.Ticks
-        let maxTicks =
-            System.DateTimeOffset.MaxValue.Ticks
-        gen {
-            let! ticks =
-                Range.constantFrom
-                    (System.DateTimeOffset (2000, 1, 1, 0, 0, 0, TimeSpan.Zero)).Ticks minTicks maxTicks
-                |> integral
-            let minOffsetMinutes = max (-14 * 60) (Operators.int ((maxTicks - ticks) / TimeSpan.TicksPerMinute) * -1)
-            let maxOffsetMinutes = min (14 * 60) (Operators.int ((ticks - minTicks) / TimeSpan.TicksPerMinute))
-            let! offsetMinutes = int (Range.exponentialFrom 0 minOffsetMinutes maxOffsetMinutes)
-            return System.DateTimeOffset(ticks, TimeSpan.FromMinutes (Operators.float offsetMinutes))
-        }
+        dateTimeOffsetRanged (Range.constantFrom (DateTimeOffset (2000, 1, 1, 0, 0, 0, TimeSpan.Zero)) DateTimeOffset.MinValue DateTimeOffset.MaxValue)
+
 
     //
     // Sampling

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -518,10 +518,6 @@ module Gen =
     /// Generates a random DateTime using the specified range.
     [<CompiledName("DateTimeRanged")>]
     let dateTimeRanged (range : Range<DateTime>) : Gen<System.DateTime> =
-        let minTicks =
-            System.DateTime.MinValue.Ticks
-        let maxTicks =
-            System.DateTime.MaxValue.Ticks
         gen {
             let! ticks = range |> Range.map (fun dt -> dt.Ticks) |> integral
             return System.DateTime ticks
@@ -530,15 +526,17 @@ module Gen =
     /// Generates a random DateTimeOffset using the specified range.
     [<CompiledName("DateTimeOffsetRanged")>]
     let dateTimeOffsetRanged (range : Range<DateTimeOffset>) : Gen<System.DateTimeOffset> =
-        let minTicks =
-            System.DateTimeOffset.MinValue.Ticks
-        let maxTicks =
-            System.DateTimeOffset.MaxValue.Ticks
         gen {
             let! ticks = range |> Range.map (fun dt -> dt.Ticks) |> integral
             // Ensure there is no overflow near the edges when adding the offset
-            let minOffsetMinutes = max (-14 * 60) (Operators.int ((maxTicks - ticks) / TimeSpan.TicksPerMinute) * -1)
-            let maxOffsetMinutes = min (14 * 60) (Operators.int ((ticks - minTicks) / TimeSpan.TicksPerMinute))
+            let minOffsetMinutes = 
+              max 
+                (-14 * 60) 
+                (Operators.int ((DateTimeOffset.MaxValue.Ticks - ticks) / TimeSpan.TicksPerMinute) * -1)
+            let maxOffsetMinutes = 
+              min 
+                (14 * 60) 
+                (Operators.int ((ticks - DateTimeOffset.MinValue.Ticks) / TimeSpan.TicksPerMinute))
             let! offsetMinutes = int (Range.exponentialFrom 0 minOffsetMinutes maxOffsetMinutes)
             return System.DateTimeOffset(ticks, TimeSpan.FromMinutes (Operators.float offsetMinutes))
         }

--- a/tests/Hedgehog.Tests/GenTests.fs
+++ b/tests/Hedgehog.Tests/GenTests.fs
@@ -13,7 +13,7 @@ open Xunit
 [<InlineData(256)>]
 [<InlineData(512)>]
 let ``dateTime creates System.DateTime instances`` count =
-    let actual = Gen.dateTime |> Gen.sample 0 count
+    let actual = Gen.dateTime (Range.constant System.DateTime.MinValue System.DateTime.MaxValue) |> Gen.sample 0 count
     actual
     |> List.distinct
     |> List.length
@@ -45,7 +45,7 @@ let ``dateTime randomly generates value between max and min ticks`` () =
         |> Random.run seed1 0
     let expected = System.DateTime ticks
 
-    let actual = Gen.dateTime
+    let actual = Gen.dateTime (Range.constant System.DateTime.MinValue System.DateTime.MaxValue)
 
     let result = actual |> Gen.toRandom |> Random.run seed0 0 |> Tree.outcome
     expected =! result
@@ -54,7 +54,9 @@ let ``dateTime randomly generates value between max and min ticks`` () =
 let ``dateTime shrinks to correct mid-value`` () =
     let result =
         property {
-            let! actual = Gen.dateTime
+            let! actual = 
+              Range.constantFrom (System.DateTime (2000, 1, 1)) System.DateTime.MinValue System.DateTime.MaxValue
+              |> Gen.dateTime
             System.DateTime.Now =! actual
         }
         |> Property.report


### PR DESCRIPTION
This PR consists of these changes, each in a separate commit:
* Improve correctness of Gen.dateTime docs (`DateTime` is decidedly not an instant in time; `DateTimeOffset` is). This change was also done for consistency with the new functions added in later commits.
* Added `Gen.dateTimeOffset`. It's a "primitive" that is non-trivial to generate (care must be taken to avoid overflows due to adding offsets around the min/max values) and should be in fsharp-hedgehog
* Added ranged variants of `Gen.dateTime` and `Gen.dateTimeOffset`, allowing users to specify their own date ranges (I have myself come across the need to limit the date ranges due to complicated time zone stuff some country did a hundred years ago, which is not interesting to account for in my domain)
* Implemented `dateTime` and `dateTimeOffset` in terms of their ranged variants

There is one other change I'd like to make, but for some reason it won't compile: I'd like to change the default range of `dateTime` and `dateTimeOffset` from `constant` to either `linear` or `exponential`. I don't see a reason why it should be size-independent. But when I tried to change it, I get compile errors:

![image](https://user-images.githubusercontent.com/7766733/101960035-c7884900-3c06-11eb-8634-ce32cfffb621.png)