### PR TITLE
Generate NuGet package during build

### DIFF
--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -6,6 +6,7 @@
     <Description>Release with confidence.</Description>
     <Authors>Jacob Stanley;Nikos Baxevanis</Authors>
     <Copyright>Copyright © 2017</Copyright>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Hedgehog</PackageId>
     <PackageDescription>


### PR DESCRIPTION
How about generating a NuGet package as part of the build?

In general, it is useful to know if some change prevents the ability to create the NuGet package.  More specifically, this helps test unreleased code.  Of course it is possible to add a direct dependency on the project, but it is easier to obtain and share the NuGet package and depend on it after putting it in a local NuGet package source.  In particular, this change would make it easier to test PR #251.