### PR TITLE
add ListGen.traverse

### DIFF
--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -32,6 +32,7 @@ https://github.com/hedgehogqa/fsharp-hedgehog/blob/master/doc/tutorial.md
     <Compile Include="Random.fs" />
     <Compile Include="Shrink.fs" />
     <Compile Include="Gen.fs" />
+    <Compile Include="ListGen.fs" />
     <Compile Include="Journal.fs" />
     <Compile Include="Tuple.fs" />
     <Compile Include="Outcome.fs" />

--- a/src/Hedgehog/ListGen.fs
+++ b/src/Hedgehog/ListGen.fs
@@ -1,0 +1,17 @@
+﻿namespace Hedgehog
+
+module ListGen =
+
+    let traverse (f: 'a -> Gen<'b>) (ma: list<'a>) : Gen<list<'b>> =
+        let rec loop input output =
+            match input with
+            | [] -> output |> List.rev |> Gen.constant
+            | a :: input ->
+                gen {
+                    let! b = f a
+                    return! loop input (b :: output)
+                }
+        loop ma []
+
+    let sequence (gens : List<Gen<'a>>) : Gen<List<'a>> =
+        gens |> traverse id

--- a/tests/Hedgehog.Tests/GenTests.fs
+++ b/tests/Hedgehog.Tests/GenTests.fs
@@ -4,6 +4,16 @@ open Hedgehog
 open Swensen.Unquote
 open Xunit
 
+
+[<Fact>]
+let ``Large input to ListGen sequence does not cause stack overflow`` () =
+  let n = 10000
+  Gen.constant 1
+  |> List.replicate n
+  |> ListGen.sequence
+  |> Gen.sample 0 1
+  |> ignore
+
 [<Theory>]
 [<InlineData(  8)>]
 [<InlineData( 16)>]

--- a/tests/Hedgehog.Tests/GenTests.fs
+++ b/tests/Hedgehog.Tests/GenTests.fs
@@ -4,16 +4,6 @@ open Hedgehog
 open Swensen.Unquote
 open Xunit
 
-
-[<Fact>]
-let ``Large input to ListGen sequence does not cause stack overflow`` () =
-  let n = 10000
-  Gen.constant 1
-  |> List.replicate n
-  |> ListGen.sequence
-  |> Gen.sample 0 1
-  |> ignore
-
 [<Theory>]
 [<InlineData(  8)>]
 [<InlineData( 16)>]


### PR DESCRIPTION
This PR adds `ListGen.traverse` and its specialization `sequence`.