### PR TITLE
automated publishing of NuGet package

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,33 @@
+name: master
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Ensure no Windows line endings
+      run: ./validate.sh
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.403
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore --configuration Release
+    - name: Test (Hedgehog.Tests)
+      run: dotnet test --no-build --configuration Release --verbosity normal tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
+    - name: Test (Hedgehog.CSharp.Tests)
+      run: dotnet test --no-build --configuration Release --verbosity normal tests/Hedgehog.CSharp.Tests/Hedgehog.CSharp.Tests.csproj
+    - name: Publish NuGet
+      uses: brandedoutcast/publish-nuget@v2.5.5
+      with:
+        PROJECT_FILE_PATH: "src/Hedgehog/Hedgehog.fsproj"
+        PACKAGE_NAME: "Hedgehog"
+        NUGET_KEY: ${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,8 +1,6 @@
-name: .NET Core
+name: Pull Request
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     types:
       - opened

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-fsharp-hedgehog [![NuGet][nuget-shield]][nuget] ![](https://github.com/hedgehogqa/fsharp-hedgehog/workflows/.NET%20Core/badge.svg)
+fsharp-hedgehog [![NuGet][nuget-shield]][nuget] ![](https://github.com/hedgehogqa/fsharp-hedgehog/workflows/master/badge.svg)
 ========
 
 > Hedgehog will eat all your bugs.


### PR DESCRIPTION
Resolves #215

This PR adds the GitHub Action called [Publish NuGet](https://github.com/marketplace/actions/publish-nuget).  When executed, it publishes a NuGet package if the version (as specified in the `Version` element in the project file) has changed.

I found it because it is being used in `fsharp-hedgehog-experimental` [here](https://github.com/hedgehogqa/fsharp-hedgehog-experimental/blob/master/.github/workflows/dotnet-core.yml#L24-L29) (and with help from @dharmaturtle).

I didn't copy things exactly as they are in `fsharp-hedgehog-experimental`.  Instead, I made it very clear when the publish NuGet package code will execute: only when `master` changes.  If the files were left together, I was concerned that anyone could create pull request that changes the version and cause a NuGet package release even without the pull request being completed.  Maybe that wouldn't be possible, but I don't think that is obvious.  By separating the files, it is obvious that this bad behavior cannot occur.