### PR TITLE
Added reportBool, reportRecheck, and reportRecheckBool

### DIFF
--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -71,6 +71,14 @@ type Property private () =
         Property.report' tests property
 
     [<Extension>]
+    static member Report (property : Property<bool>) : Report =
+        Property.reportBool property
+
+    [<Extension>]
+    static member Report (property : Property<bool>, tests : int<tests>) : Report =
+        Property.reportBool' tests property
+
+    [<Extension>]
     static member Check (property : Property<unit>) : unit =
         Property.check property
 
@@ -101,6 +109,22 @@ type Property private () =
     [<Extension>]
     static member Recheck (property : Property<bool>, size : Size, seed : Seed, tests : int<tests>) : unit =
         Property.recheckBool' size seed tests property
+
+    [<Extension>]
+    static member ReportRecheck (property : Property<unit>, size : Size, seed : Seed) : Report =
+        Property.reportRecheck size seed property
+
+    [<Extension>]
+    static member ReportRecheck (property : Property<unit>, size : Size, seed : Seed, tests : int<tests>) : Report =
+        Property.reportRecheck' size seed tests property
+
+    [<Extension>]
+    static member ReportRecheck (property : Property<bool>, size : Size, seed : Seed) : Report =
+        Property.reportRecheckBool size seed property
+
+    [<Extension>]
+    static member ReportRecheck (property : Property<bool>, size : Size, seed : Seed, tests : int<tests>) : Report =
+        Property.reportRecheckBool' size seed tests property
 
     [<Extension>]
     static member Print (property : Property<unit>, tests : int<tests>) : unit =

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -363,6 +363,12 @@ module Property =
     let report (p : Property<unit>) : Report =
         report' 100<tests> p
 
+    let reportBool' (n : int<tests>) (p : Property<bool>) : Report =
+        bind p ofBool |> report' n
+
+    let reportBool (p : Property<bool>) : Report =
+        bind p ofBool |> report
+
     let check' (n : int<tests>) (p : Property<unit>) : unit =
         report' n p
         |> Report.tryRaise
@@ -386,12 +392,24 @@ module Property =
         with
         | _ -> failure
 
-    let recheck' (size : Size) (seed : Seed) (n : int<tests>) (p : Property<unit>) : unit =
+    let reportRecheck' (size : Size) (seed : Seed) (n : int<tests>) (p : Property<unit>) : Report =
         reportWith' false size seed n p
+
+    let reportRecheck (size : Size) (seed : Seed) (p : Property<unit>) : Report =
+        reportWith false size seed p
+
+    let reportRecheckBool' (size : Size) (seed : Seed) (n : int<tests>) (p : Property<bool>) : Report =
+        bind p ofBool |> reportRecheck' size seed n
+
+    let reportRecheckBool (size : Size) (seed : Seed) (p : Property<bool>) : Report =
+        bind p ofBool |> reportRecheck size seed
+
+    let recheck' (size : Size) (seed : Seed) (n : int<tests>) (p : Property<unit>) : unit =
+        reportRecheck' size seed n p
         |> Report.tryRaise
 
     let recheck (size : Size) (seed : Seed) (p : Property<unit>) : unit =
-        reportWith false size seed p
+        reportRecheck size seed p
         |> Report.tryRaise
 
     let recheckBool' (size : Size) (seed : Seed) (n : int<tests>) (g : Property<bool>) : unit =


### PR DESCRIPTION
It would be easier for Hedgehog.Xunit to implement `[<Recheck(size, seed)>]` if `reportRecheck` existed. I threw in `reportBool` as a bonus.

https://github.com/hedgehogqa/fsharp-hedgehog/pull/266 should probably go first, which'll break this PR but I'll fix it once it's in.