### PR TITLE
Add render functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ let propReverse : Property<Unit> =
 You can then load the module in F# Interactive, and run it:
 
 ```
-> Property.print propReverse
+> Property.render propReverse |> printfn "%s"
 +++ OK, passed 100 tests.
 ```
 
@@ -62,7 +62,7 @@ class Generators
         var stringLength = 10;
         var stringGen = Gen.String(Gen.Alpha, Range.FromValue(stringLength));
 
-        // This creates a property that can be printed, checked, or re-checked.
+        // This creates a property that can be checked, rechecked or rendered.
         var property =
             from string in Property.ForAll(stringGen)
             select Assert.AreEqual(stringLength, string.Length);

--- a/doc/index.md
+++ b/doc/index.md
@@ -32,14 +32,15 @@ property {
 }
 ```
 
-and to test the above property on 100 random lists of integers, pipe it into `Property.print`:
+and to test the above property on 100 random lists of integers, pipe it into `Property.render`:
 
 ```fs
 property {
     let! xs = Range.constant 0 1000 |> Gen.int |> Gen.list (Range.linear 0 100)
     return List.rev (List.rev xs) = xs
 }
-|> Property.print
+|> Property.render
+|> printfn "%s"
 
 +++ OK, passed 100 tests.
 ```
@@ -53,7 +54,8 @@ Hedgehog comes with built-in generators for primitive types, so here's how it wo
 ```fs
 Range.constant 0 100
 |> Gen.int
-|> Gen.printSample;;
+|> Gen.renderSample
+|> printfn "%s";;
 
 === Outcome ===
 77
@@ -111,7 +113,8 @@ Range.constantBounded ()
 |> Gen.map int
 |> Gen.tuple3
 |> Gen.map (fun (ma, mi, bu) -> Version (ma, mi, bu))
-|> Gen.printSample;;
+|> Gen.renderSample
+|> printfn "%s";;
 
 === Outcome ===
 60.8.252
@@ -251,10 +254,12 @@ let version =
     |> Gen.tuple3
     |> Gen.map (fun (ma, mi, bu) -> Version (ma, mi, bu))
 
-Property.print (property {
+property {
     let! xs = Gen.list (Range.linear 0 100) version
     return xs |> List.rev = xs
-})
+}
+|> Property.render
+|> printfn "%s"
 
 >
 *** Failed! Falsifiable (after 3 tests and 6 shrinks):
@@ -298,7 +303,7 @@ Gen.alphaNum
 This generator is of type `Gen<char>`, which means that Hedgehog can take this generator and produce characters, like so:
 
 ```fs
-Gen.alphaNum |> Gen.printSample;;
+Gen.alphaNum |> Gen.renderSample |> printfn "%s";;
 
 === Outcome ===
 '3'
@@ -358,7 +363,7 @@ let ipAddressGen : Gen<IPAddress> = gen {
     return System.Net.IPAddress addr
 }
 
-ipAddressGen |> Gen.printSample;;
+ipAddressGen |> Gen.renderSample |> printfn "%s";;
 
 === Outcome ===
 45.230.61.78
@@ -536,7 +541,8 @@ property { let! a = Range.constantBounded () |> Gen.int
            let! b = Range.constantBounded () |> Gen.int
            counterexample (sprintf "The value of a was %d." a)
            return tryAdd a b = Some(a + b) }
-|> Property.print;;
+|> Property.render
+|> printfn "%s";;
 
 >
 *** Failed! Falsifiable (after 16 tests and 5 shrinks):
@@ -559,7 +565,8 @@ property { let! a = Range.constantBounded () |> Gen.int
            let! b = Range.constantBounded () |> Gen.int
            where (a < 100)
            return tryAdd a b = Some(a + b) }
-|> Property.print;;
+|> Property.render
+|> printfn "%s";;
 
 >
 *** Gave up after 100 discards, passed 95 tests.
@@ -568,7 +575,7 @@ property { let! a = Range.constantBounded () |> Gen.int
 
 Essentially, the `where` custom operation discards test cases which do not satisfy the given condition.
 
-Test case generation continues until 100 cases (the default of `Property.print`) which do satisfy the condition have been found, or until an overall limit on the number of test cases is reached (to avoid looping if the condition never holds).
+Test case generation continues until 100 cases (the default of `Property.render`) which do satisfy the condition have been found, or until an overall limit on the number of test cases is reached (to avoid looping if the condition never holds).
 
 In this case a message such as
 
@@ -662,10 +669,12 @@ Here's a way to use it:
 ```fs
 let pattern = "^http\://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(/\S*)?$"
 
-Property.print (property {
+property {
     let! s = fromRegex pattern
     return matches s pattern
-})
+}
+|> Property.render
+|> printfn "%s"
 
 +++ OK, passed 100 tests.
 

--- a/doc/property.md
+++ b/doc/property.md
@@ -81,14 +81,15 @@ property {
     let! xs = g
     return List.rev (List.rev xs) = xs
 }
-|> Property.printWith propConfig;;
+|> Property.renderWith propConfig
+|> printfn "%s";;
 
 >
 +++ OK, passed 500 tests.
 
 ```
 
-The above property was exercised 500 times. The default is 100, which is what `Property.print` does:
+The above property was exercised 500 times. The default is 100, which is what `Property.render` does:
 
 ```fs
 let g = Gen.list (Range.linear 0 100) Gen.alpha
@@ -116,7 +117,8 @@ let tryAdd a b =
 property { let! a = Range.constantBounded () |> Gen.int
            let! b = Range.constantBounded () |> Gen.int
            return tryAdd a b = Some (a + b) }
-|> Property.print;;
+|> Property.render
+|> printfn "%s";;
 
 >
 *** Failed! Falsifiable (after 3 tests and 24 shrinks):

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -502,7 +502,7 @@ module Gen =
         toRandom g
         |> Random.run seed 30
 
-    let formatSample (gen : Gen<'a>) : string =
+    let renderSample (gen : Gen<'a>) : string =
         String.concat Environment.NewLine [
             let forest = sampleTree 10 5 gen
             for tree in forest do
@@ -513,9 +513,6 @@ module Gen =
                     yield sprintf "%A" (Tree.outcome shrink)
                 yield "."
         ]
-
-    let printSample (gen : Gen<'a>) : unit =
-        printfn "%s" (formatSample gen)
 
     module Operators =
         let (<!>) f g = map f g

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -502,15 +502,20 @@ module Gen =
         toRandom g
         |> Random.run seed 30
 
+    let asString (g : Gen<'a>) : string =
+        String.concat Environment.NewLine [
+            let forest = sampleTree 10 5 g
+            for tree in forest do
+                yield "=== Outcome ==="
+                yield sprintf "%A" (Tree.outcome tree)
+                yield "=== Shrinks ==="
+                for shrink in Tree.shrinks tree do
+                    yield sprintf "%A" (Tree.outcome shrink)
+                yield "."
+        ]
+
     let printSample (g : Gen<'a>) : unit =
-        let forest = sampleTree 10 5 g
-        for tree in forest do
-            printfn "=== Outcome ==="
-            printfn "%A" (Tree.outcome tree)
-            printfn "=== Shrinks ==="
-            for shrink in Tree.shrinks tree do
-                printfn "%A" (Tree.outcome shrink)
-            printfn "."
+        printfn "%s" (asString g)
 
     module Operators =
         let (<!>) f g = map f g

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -502,9 +502,9 @@ module Gen =
         toRandom g
         |> Random.run seed 30
 
-    let asString (g : Gen<'a>) : string =
+    let formatSample (gen : Gen<'a>) : string =
         String.concat Environment.NewLine [
-            let forest = sampleTree 10 5 g
+            let forest = sampleTree 10 5 gen
             for tree in forest do
                 yield "=== Outcome ==="
                 yield sprintf "%A" (Tree.outcome tree)
@@ -514,8 +514,8 @@ module Gen =
                 yield "."
         ]
 
-    let printSample (g : Gen<'a>) : unit =
-        printfn "%s" (asString g)
+    let printSample (gen : Gen<'a>) : unit =
+        printfn "%s" (formatSample gen)
 
     module Operators =
         let (<!>) f g = map f g

--- a/src/Hedgehog/Linq/Gen.fs
+++ b/src/Hedgehog/Linq/Gen.fs
@@ -178,12 +178,8 @@ type GenExtensions private () =
         Gen.option gen |> Gen.map (Option.defaultWith Nullable << Option.map Nullable)
 
     [<Extension>]
-    static member FormatSample (gen : Gen<'T>) : string =
-        Gen.formatSample gen
-
-    [<Extension>]
-    static member PrintSample (gen : Gen<'T>) : unit =
-        Gen.printSample gen
+    static member RenderSample (gen : Gen<'T>) : string =
+        Gen.renderSample gen
 
     [<Extension>]
     static member Resize (gen : Gen<'T>, size : Size) : Gen<'T> =

--- a/src/Hedgehog/Linq/Gen.fs
+++ b/src/Hedgehog/Linq/Gen.fs
@@ -178,8 +178,8 @@ type GenExtensions private () =
         Gen.option gen |> Gen.map (Option.defaultWith Nullable << Option.map Nullable)
 
     [<Extension>]
-    static member AsString (gen : Gen<'T>) : string =
-        Gen.asString gen
+    static member FormatSample (gen : Gen<'T>) : string =
+        Gen.formatSample gen
 
     [<Extension>]
     static member PrintSample (gen : Gen<'T>) : unit =

--- a/src/Hedgehog/Linq/Gen.fs
+++ b/src/Hedgehog/Linq/Gen.fs
@@ -178,6 +178,10 @@ type GenExtensions private () =
         Gen.option gen |> Gen.map (Option.defaultWith Nullable << Option.map Nullable)
 
     [<Extension>]
+    static member AsString (gen : Gen<'T>) : string =
+        Gen.asString gen
+
+    [<Extension>]
     static member PrintSample (gen : Gen<'T>) : unit =
         Gen.printSample gen
 

--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -139,6 +139,24 @@ type PropertyExtensions private () =
         Property.reportRecheckBoolWith size seed config property
 
     [<Extension>]
+    static member Render (property : Property) : string =
+        let (Property property) = property
+        Property.render property
+
+    [<Extension>]
+    static member Render (property : Property, config : Hedgehog.PropertyConfig) : string =
+        let (Property property) = property
+        Property.renderWith config property
+
+    [<Extension>]
+    static member Render (property : Property<bool>) : string =
+        Property.renderBool property
+
+    [<Extension>]
+    static member Render (property : Property<bool>, config : Hedgehog.PropertyConfig) : string =
+        Property.renderBoolWith config property
+
+    [<Extension>]
     static member Where (property : Property<'T>, filter : Func<'T, bool>) : Property<'T> =
         Property.filter filter.Invoke property
 

--- a/src/Hedgehog/Linq/PropertyConfig.fs
+++ b/src/Hedgehog/Linq/PropertyConfig.fs
@@ -10,7 +10,8 @@ open Hedgehog
 [<AbstractClass; Sealed>]
 type PropertyConfigExtensions private () =
 
-    /// Set the number of times a property is allowed to shrink before the test runner gives up and prints the counterexample.
+    /// Set the number of times a property is allowed to shrink before the test
+    /// runner gives up and displays the counterexample.
     [<Extension>]
     static member WithShrinks (config : PropertyConfig, shrinkLimit: int<shrinks>) : PropertyConfig =
         PropertyConfig.withShrinks shrinkLimit config
@@ -20,7 +21,8 @@ type PropertyConfigExtensions private () =
     static member WithoutShrinks (config : PropertyConfig) : PropertyConfig =
         PropertyConfig.withoutShrinks config
 
-    /// Set the number of times a property should be executed before it is considered successful.
+    /// Set the number of times a property should be executed before it is
+    /// considered successful.
     [<Extension>]
     static member WithTests (config : PropertyConfig, testLimit: int<tests>) : PropertyConfig =
         PropertyConfig.withTests testLimit config

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -241,31 +241,36 @@ module Property =
     let recheckBool (size : Size) (seed : Seed) (g : Property<bool>) : unit =
         g |> bind ofBool |> recheck size seed
 
-    let printWith (config : PropertyConfig) (p : Property<unit>) : unit =
-        reportWith config p
-        |> Report.render
-        |> printfn "%s"
-
-    let formatWith (n : PropertyConfig) (p : Property<unit>) : string =
+    let renderWith (n : PropertyConfig) (p : Property<unit>) : string =
         reportWith n p
         |> Report.render
 
-    let format (p : Property<unit>) : string =
+    let render (p : Property<unit>) : string =
         report p
         |> Report.render
 
     let print (p : Property<unit>) : unit =
-        format p
+        render p
         |> printfn "%s"
 
-    let printBoolWith (config : PropertyConfig) (p : Property<bool>) : unit =
+    let renderBool (property : Property<bool>) : string =
+        reportBool property
+        |> Report.render
+
+    let renderBoolWith (config : PropertyConfig) (p : Property<bool>) : string =
         reportBoolWith config p
         |> Report.render
+
+    let printBoolWith (config : PropertyConfig) (p : Property<bool>) : unit =
+        renderBoolWith config p
+        |> printfn "%s"
+
+    let printWith (config : PropertyConfig) (p : Property<unit>) : unit =
+        renderWith config p
         |> printfn "%s"
 
     let printBool (p : Property<bool>) : unit =
-        reportBool p
-        |> Report.render
+        renderBool p
         |> printfn "%s"
 
 [<AutoOpen>]

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -249,10 +249,6 @@ module Property =
         report p
         |> Report.render
 
-    let print (p : Property<unit>) : unit =
-        render p
-        |> printfn "%s"
-
     let renderBool (property : Property<bool>) : string =
         reportBool property
         |> Report.render
@@ -260,18 +256,6 @@ module Property =
     let renderBoolWith (config : PropertyConfig) (p : Property<bool>) : string =
         reportBoolWith config p
         |> Report.render
-
-    let printBoolWith (config : PropertyConfig) (p : Property<bool>) : unit =
-        renderBoolWith config p
-        |> printfn "%s"
-
-    let printWith (config : PropertyConfig) (p : Property<unit>) : unit =
-        renderWith config p
-        |> printfn "%s"
-
-    let printBool (p : Property<bool>) : unit =
-        renderBool p
-        |> printfn "%s"
 
 [<AutoOpen>]
 module PropertyBuilder =

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -246,14 +246,17 @@ module Property =
         |> Report.render
         |> printfn "%s"
 
-    let asStringWith (n : PropertyConfig) (p : Property<unit>) : string =
-        Report.render <| reportWith n p
+    let formatWith (n : PropertyConfig) (p : Property<unit>) : string =
+        reportWith n p
+        |> Report.render
 
-    let asString (p : Property<unit>) : string =
-        Report.render <| report p
+    let format (p : Property<unit>) : string =
+        report p
+        |> Report.render
 
     let print (p : Property<unit>) : unit =
-        printfn "%s" <| asString p
+        format p
+        |> printfn "%s"
 
     let printBoolWith (config : PropertyConfig) (p : Property<bool>) : unit =
         reportBoolWith config p

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -246,10 +246,14 @@ module Property =
         |> Report.render
         |> printfn "%s"
 
+    let asStringWith (n : PropertyConfig) (p : Property<unit>) : string =
+        Report.render <| reportWith n p
+
+    let asString (p : Property<unit>) : string =
+        Report.render <| report p
+
     let print (p : Property<unit>) : unit =
-        report p
-        |> Report.render
-        |> printfn "%s"
+        printfn "%s" <| asString p
 
     let printBoolWith (config : PropertyConfig) (p : Property<bool>) : unit =
         reportBoolWith config p

--- a/src/Hedgehog/PropertyConfig.fs
+++ b/src/Hedgehog/PropertyConfig.fs
@@ -13,7 +13,7 @@ module PropertyConfig =
           ShrinkLimit = None }
 
     /// Set the number of times a property is allowed to shrink before the test
-    /// runner gives up and prints the counterexample.
+    /// runner gives up and displays the counterexample.
     let withShrinks (shrinkLimit : int<shrinks>) (config : PropertyConfig) : PropertyConfig =
         { config with ShrinkLimit = Some shrinkLimit }
 


### PR DESCRIPTION
Fixes #226 the name for `Gen.printSample` would be awkward (`Gen.toStringSample`) if the convention were followed.

/cc @moodmosaic @TysonMN 