### PR TITLE
Hide unit type from LINQ interface

### DIFF
--- a/src/Hedgehog/Linq/Gen.fs
+++ b/src/Hedgehog/Linq/Gen.fs
@@ -6,8 +6,6 @@ open System
 open System.Runtime.CompilerServices
 open Hedgehog
 
-[<Extension>]
-[<AbstractClass; Sealed>]
 type Gen private () =
 
     static member FromValue (value : 'T) : Gen<'T> =
@@ -141,6 +139,10 @@ type Gen private () =
 
     static member DateTimeOffset (range : Range<DateTimeOffset>) : Gen<DateTimeOffset> =
         Gen.dateTimeOffset range
+
+[<Extension>]
+[<AbstractClass; Sealed>]
+type GenExtensions private () =
 
     [<Extension>]
     static member Apply (genFunc : Gen<Func<'T, 'TResult>>, genArg : Gen<'T>) : Gen<'TResult> =

--- a/src/Hedgehog/Linq/Range.fs
+++ b/src/Hedgehog/Linq/Range.fs
@@ -6,8 +6,6 @@ open System
 open System.Runtime.CompilerServices
 open Hedgehog
 
-[<Extension>]
-[<AbstractClass; Sealed>]
 type Range private () =
 
     //
@@ -419,6 +417,10 @@ type Range private () =
     /// parameter and uses the full range of a data type.
     static member ExponentialBoundedDecimal () : Range<decimal> =
         Range.exponentialBounded ()
+
+[<Extension>]
+[<AbstractClass; Sealed>]
+type RangeExtensions private () =
 
     [<Extension>]
     static member Select (range : Range<'T>, mapper : Func<'T, 'TResult>) : Range<'TResult> =


### PR DESCRIPTION
The purpose of this PR is to hide another F# detail from the LINQ interface, in this case the `unit` type. When used as a return type, `unit` becomes `void`, but when used as a type argument then it remains as `FSharp.Core.Unit`. To solve this I've introduced the `Property` type, that just conceals a `Property<unit>` (ie, this is _not_ an alias). Then from C#/VB a user would just see this simple type instead of `Property<FSharp.Core.Unit>`.

/cc @moodmosaic @TysonMN