### PR TITLE
Fix fable include

### DIFF
--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -43,6 +43,6 @@ https://github.com/hedgehogqa/fsharp-hedgehog/blob/master/doc/tutorial.md
   </ItemGroup>
   <!-- https://fable.io/docs/your-fable-project/author-a-fable-library.html -->
   <ItemGroup>
-    <Content Include="*.fsproj; **\*.fs" PackagePath="fable\" />
+    <Content Include="*.fsproj; **\*.fs" Exclude="**\bin\**\*; **\obj\**\*" PackagePath="fable" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #278

A few issues:

- Files under the `obj` folder were being included, some auto-generated `AssemblyInfo.fs` file or something, and these made it all the way into the nuget package.
- The `PackagePath` ended in a `\` which caused a weird pathing issue in the nuget package as well.

/cc @moodmosaic @TysonMN