### PR TITLE
Add OptionTree.traverse

### DIFF
--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -275,15 +275,9 @@ module Gen =
 
     /// Tries to generate a value that satisfies a predicate.
     let tryFilter (p : 'a -> bool) (g : Gen<'a>) : Gen<'a option> =
-        let filter = function
-            | None ->
-                Tree.singleton None |> Random.constant
-            | Some x ->
-                Random.constant (Tree.map Some x)
-
         toRandom g
         |> tryFilterRandom p
-        |> flip Random.bind filter
+        |> flip Random.bind (OptionTree.sequence >> Random.constant)
         |> ofRandom
 
     /// Runs an option generator until it produces a 'Some'.

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -281,11 +281,9 @@ module Gen =
             | Some x ->
                 Random.constant (Tree.map Some x)
 
-        let flipBind f ma = Random.bind ma f
-
         toRandom g
         |> tryFilterRandom p
-        |> flipBind filter
+        |> flip Random.bind filter
         |> ofRandom
 
     /// Runs an option generator until it produces a 'Some'.

--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -28,6 +28,7 @@ https://github.com/hedgehogqa/fsharp-hedgehog/blob/master/doc/tutorial.md
     <Compile Include="Numeric.fs" />
     <Compile Include="Seed.fs" />
     <Compile Include="Tree.fs" />
+    <Compile Include="OptionTree.fs" />
     <Compile Include="Range.fs" />
     <Compile Include="Random.fs" />
     <Compile Include="Shrink.fs" />

--- a/src/Hedgehog/OptionTree.fs
+++ b/src/Hedgehog/OptionTree.fs
@@ -1,0 +1,11 @@
+﻿[<RequireQualifiedAccess>]
+module internal Hedgehog.OptionTree
+
+
+let traverse (f: 'a -> Tree<'b>) (maybeTree: 'a option) : Tree<'b option> =
+  match maybeTree with
+  | None -> None |> Tree.singleton
+  | Some t -> t |> f |> Tree.map Some
+
+let sequence (maybeTree: Tree<'a> option) : Tree<'a option> =
+  traverse id maybeTree

--- a/src/Hedgehog/OptionTree.fs
+++ b/src/Hedgehog/OptionTree.fs
@@ -1,7 +1,6 @@
 ﻿[<RequireQualifiedAccess>]
 module internal Hedgehog.OptionTree
 
-
 let traverse (f: 'a -> Tree<'b>) (maybeTree: 'a option) : Tree<'b option> =
   match maybeTree with
   | None -> None |> Tree.singleton


### PR DESCRIPTION
This PR adds `OptionTree.traverse`.  It uses the same naming convention I have been arguing for in PR https://github.com/hedgehogqa/fsharp-hedgehog/pull/260#discussion_r551046128.

However, to hopefully avoid the same discussion here, I made that module internal.  That way, we can easily change the name (i.e. without a breaking change).