### PR TITLE
Update remote dev files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,6 +9,9 @@ RUN apt update && apt -y install --no-install-recommends --no-install-suggests \
  && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1000 dev \
- && useradd -g 1000 -u 1000 -m -s /bin/bash dev
+ && useradd -g 1000 -u 1000 -m -s /bin/bash dev \
+ && mkdir -p /home/dev/.vscode-server/extensions \
+ && mkdir -p /home/dev/.vscode-server/extensionsCache \
+ && chown -R dev:dev /home/dev
 
 USER dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,15 @@
 {
-  "dockerFile": "Dockerfile",
+  "dockerComposeFile": "docker-compose.yml",
+  "postAttachCommand": "rm -rf .ionide",
+  "service": "dev",
+  "workspaceFolder": "/workspace",
+
   "extensions": [
-    "ionide.ionide-fsharp"
+    "editorconfig.editorconfig",
+    "ionide.ionide-fsharp@4.17.0"
   ],
+
   "settings": {
-    "[csharp]": {
-      "editor.useTabStops": false,
-      "editor.tabSize": 4
-    },
-
-    "[fsharp]": {
-      "editor.useTabStops": false,
-      "editor.tabSize": 4
-    },
-
     "FSharp.useSdkScripts": true
   }
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.0'
+services:
+  dev:
+    build: .
+    command: sleep infinity
+    volumes:
+      - ..:/workspace
+      - vscode-extensions:/home/dev/.vscode-server/extensions
+      - vscode-extensions-cache:/home/dev/.vscode-server/extensionsCache
+
+# Persist extensions to prevent downloading again after a rebuild.
+volumes:
+  vscode-extensions:
+  vscode-extensions-cache:

--- a/tests/Hedgehog.Linq.Tests/Hedgehog.Linq.Tests.csproj
+++ b/tests/Hedgehog.Linq.Tests/Hedgehog.Linq.Tests.csproj
@@ -15,5 +15,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Hedgehog\Hedgehog.fsproj" />
+    <Reference Include="Hedgehog">
+      <HintPath>..\..\src\Hedgehog\bin\Debug\netstandard2.0\Hedgehog.dll</HintPath>
+    </Reference>
   </ItemGroup>
 </Project>

--- a/tests/Hedgehog.Linq.Tests/Hedgehog.Linq.Tests.csproj
+++ b/tests/Hedgehog.Linq.Tests/Hedgehog.Linq.Tests.csproj
@@ -15,8 +15,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Hedgehog\Hedgehog.fsproj" />
-    <Reference Include="Hedgehog">
-      <HintPath>..\..\src\Hedgehog\bin\Debug\netstandard2.0\Hedgehog.dll</HintPath>
-    </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR addresses some issues/changes with the project, just a quick overview:

- Use a `docker-compose.yml` file to mount in a volume to cache vscode extensions.
- Switch to using the `.editorconfig` that was added in #273.
- Ionide version 5 switched to requiring .NET 5, which this project doesn't yet support. So I've pinned the last version that works with .NET Core 3.0.
- Also, there's an issue with these extensions working across language barriers, this part I can remove. I changed `Hedgehog.Linq.Tests.csproj` to reference the local path for `Hedgehog.dll` so that omnisharp can find it. This was more useful when I was writing the LINQ interface.