### PR TITLE
Added PropertyConfig

### DIFF
--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -78,6 +78,13 @@ type Property = private Property of Property<unit> with
     static member ForAll (gen : Gen<'T>) : Property<'T> =
         Property.forAll' gen
 
+
+module internal PropertyConfig =
+    let coalesce = function
+        | Some x -> x
+        | None -> PropertyConfig.defaultConfig
+
+
 [<Extension>]
 [<AbstractClass; Sealed>]
 type PropertyExtensions private () =
@@ -99,40 +106,72 @@ type PropertyExtensions private () =
     //
 
     [<Extension>]
-    static member Report (property : Property) : Report =
+    static member Report
+        (   property : Property,
+            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
+        ) : Report =
         let (Property property) = property
-        Property.report property
+        Property.reportWith (PropertyConfig.coalesce config) property
 
     [<Extension>]
-    static member Report (property : Property<bool>) : Report =
-        Property.reportBool property
+    static member Report
+        (   property : Property<bool>,
+            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
+        ) : Report =
+        Property.reportBoolWith (PropertyConfig.coalesce config) property
 
     [<Extension>]
-    static member Check (property : Property, config : Hedgehog.PropertyConfig) : unit =
+    static member Check
+        (   property : Property,
+            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
+        ) : unit =
         let (Property property) = property
-        Property.checkWith config property
+        Property.checkWith (PropertyConfig.coalesce config) property
 
     [<Extension>]
-    static member Check (property : Property<bool>, config : Hedgehog.PropertyConfig) : unit =
-        Property.checkBoolWith config property
+    static member Check
+        (   property : Property<bool>,
+            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
+        ) : unit =
+        Property.checkBoolWith (PropertyConfig.coalesce config) property
 
     [<Extension>]
-    static member Recheck (property : Property, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : unit =
+    static member Recheck
+        (   property : Property,
+            size : Size,
+            seed : Seed,
+            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
+        ) : unit =
         let (Property property) = property
-        Property.recheckWith size seed config property
+        Property.recheckWith size seed (PropertyConfig.coalesce config) property
 
     [<Extension>]
-    static member Recheck (property : Property<bool>, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : unit =
-        Property.recheckBoolWith size seed config property
+    static member Recheck
+        (   property : Property<bool>,
+            size : Size,
+            seed : Seed,
+            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
+        ) : unit =
+        Property.recheckBoolWith size seed (PropertyConfig.coalesce config) property
 
     [<Extension>]
-    static member ReportRecheck (property : Property, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : Report =
+    static member ReportRecheck
+        (   property : Property,
+            size : Size,
+            seed : Seed,
+            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
+        ) : Report =
         let (Property property) = property
-        Property.reportRecheckWith size seed config property
+        Property.reportRecheckWith size seed (PropertyConfig.coalesce config) property
 
     [<Extension>]
-    static member ReportRecheck (property : Property<bool>, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : Report =
-        Property.reportRecheckBoolWith size seed config property
+    static member ReportRecheck
+        (   property : Property<bool>,
+            size : Size,
+            seed : Seed,
+            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
+        ) : Report =
+        Property.reportRecheckBoolWith size seed (PropertyConfig.coalesce config) property
 
     [<Extension>]
     static member Where (property : Property<'T>, filter : Func<'T, bool>) : Property<'T> =

--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -7,15 +7,6 @@ open System.Runtime.CompilerServices
 open Hedgehog
 open System.Runtime.InteropServices
 
-module internal Build =
-    let config testLimit shrinkLimit =
-        PropertyConfig.defaultConfig
-        |> PropertyConfig.withTests (testLimit |> Option.defaultValue PropertyConfig.defaultConfig.TestLimit)
-        |> fun config ->
-            match shrinkLimit with
-            | Some shrinkLimit -> config |> PropertyConfig.withShrinks shrinkLimit
-            | None -> config
-
 
 [<Extension>]
 [<AbstractClass; Sealed>]
@@ -117,23 +108,6 @@ type PropertyExtensions private () =
         Property.reportBool property
 
     [<Extension>]
-    static member Check
-        (   property : Property,
-            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
-            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
-        ) : unit =
-        let (Property property) = property
-        Property.checkWith (Build.config testLimit shrinkLimit) property
-
-    [<Extension>]
-    static member Check
-        (   property : Property<bool>,
-            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
-            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
-        ) : unit =
-        Property.checkBoolWith (Build.config testLimit shrinkLimit) property
-
-    [<Extension>]
     static member Check (property : Property, config : Hedgehog.PropertyConfig) : unit =
         let (Property property) = property
         Property.checkWith config property
@@ -141,27 +115,6 @@ type PropertyExtensions private () =
     [<Extension>]
     static member Check (property : Property<bool>, config : Hedgehog.PropertyConfig) : unit =
         Property.checkBoolWith config property
-
-    [<Extension>]
-    static member Recheck
-        (   property : Property,
-            size : Size,
-            seed : Seed,
-            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
-            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
-        ) : unit =
-        let (Property property) = property
-        Property.recheckWith size seed (Build.config testLimit shrinkLimit) property
-
-    [<Extension>]
-    static member Recheck
-        (   property : Property<bool>,
-            size : Size,
-            seed : Seed,
-            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
-            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
-        ) : unit =
-        Property.recheckBoolWith size seed (Build.config testLimit shrinkLimit) property
 
     [<Extension>]
     static member Recheck (property : Property, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : unit =
@@ -173,27 +126,6 @@ type PropertyExtensions private () =
         Property.recheckBoolWith size seed config property
 
     [<Extension>]
-    static member ReportRecheck
-        (   property : Property,
-            size : Size,
-            seed : Seed,
-            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
-            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
-        ) : Report =
-        let (Property property) = property
-        Property.reportRecheckWith size seed (Build.config testLimit shrinkLimit) property
-
-    [<Extension>]
-    static member ReportRecheck
-        (   property : Property<bool>,
-            size : Size,
-            seed : Seed,
-            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
-            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
-        ) : Report =
-        Property.reportRecheckBoolWith size seed (Build.config testLimit shrinkLimit) property
-
-    [<Extension>]
     static member ReportRecheck (property : Property, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : Report =
         let (Property property) = property
         Property.reportRecheckWith size seed config property
@@ -201,23 +133,6 @@ type PropertyExtensions private () =
     [<Extension>]
     static member ReportRecheck (property : Property<bool>, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : Report =
         Property.reportRecheckBoolWith size seed config property
-
-    [<Extension>]
-    static member Print
-        (   property : Property,
-            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
-            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
-        ) : unit =
-        let (Property property) = property
-        Property.printWith (Build.config testLimit shrinkLimit) property
-
-    [<Extension>]
-    static member Print
-        (   property : Property<bool>,
-            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
-            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
-        ) : unit =
-        Property.printBoolWith (Build.config testLimit shrinkLimit) property
 
     [<Extension>]
     static member Where (property : Property<'T>, filter : Func<'T, bool>) : Property<'T> =

--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -5,6 +5,16 @@ namespace Hedgehog.Linq
 open System
 open System.Runtime.CompilerServices
 open Hedgehog
+open System.Runtime.InteropServices
+
+module internal Build =
+    let config tests shrinkLimit =
+        PropertyConfig.defaultConfig
+        |> PropertyConfig.withTestCount (tests |> Option.defaultValue PropertyConfig.defaultConfig.TestCount)
+        |> fun config ->
+            match shrinkLimit with
+            | Some shrinkLimit -> config |> PropertyConfig.withShrinkLimit shrinkLimit
+            | None -> config
 
 type Property = private Property of Property<unit> with
 
@@ -75,94 +85,67 @@ type PropertyExtensions private () =
         Property.report property
 
     [<Extension>]
-    static member Report (property : Property, tests : int<tests>, maxShrinks : int<shrinks>) : Report =
-        let (Property property) = property
-        Property.report'' tests maxShrinks property
-
-    [<Extension>]
-    static member Report (property : Property, tests : int<tests>) : Report =
-        let (Property property) = property
-        Property.report' tests property
-
-    [<Extension>]
     static member Report (property : Property<bool>) : Report =
         Property.reportBool property
 
     [<Extension>]
-    static member Report (property : Property<bool>, tests : int<tests>) : Report =
-        Property.reportBool' tests property
-
-    [<Extension>]
-    static member Report (property : Property<bool>, tests : int<tests>, maxShrinks : int<shrinks>) : Report =
-        Property.reportBool'' tests maxShrinks property
-
-    [<Extension>]
-    static member Check (property : Property) : unit =
+    static member Check
+        (   property : Property,
+            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
+        ) : unit =
         let (Property property) = property
-        Property.check property
+        Property.checkWith (Build.config tests shrinkLimit) property
 
     [<Extension>]
-    static member Check (property : Property, tests : int<tests>, maxShrinks : int<shrinks>) : unit =
+    static member Check
+        (   property : Property<bool>,
+            [<Optional; DefaultParameterValue null>] ?tests : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
+        ) : unit =
+        Property.checkBoolWith (Build.config tests shrinkLimit) property
+
+    [<Extension>]
+    static member Recheck
+        (   property : Property,
+            size : Size,
+            seed : Seed,
+            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
+        ) : unit =
         let (Property property) = property
-        Property.check'' tests maxShrinks property
+        Property.recheckWith size seed (Build.config tests shrinkLimit) property
 
     [<Extension>]
-    static member Check (property : Property, tests : int<tests>) : unit =
+    static member Recheck
+        (   property : Property<bool>,
+            size : Size,
+            seed : Seed,
+            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
+        ) : unit =
+        Property.recheckBoolWith size seed (Build.config tests shrinkLimit) property
+
+    [<Extension>]
+    static member ReportRecheck
+        (   property : Property,
+            size : Size,
+            seed : Seed,
+            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
+        ) : Report =
         let (Property property) = property
-        Property.check' tests property
+        Property.reportRecheckWith size seed (Build.config tests shrinkLimit) property
 
     [<Extension>]
-    static member Check (property : Property<bool>) : unit =
-        Property.checkBool property
-
-    [<Extension>]
-    static member Check (property : Property<bool>, tests : int<tests>) : unit =
-        Property.checkBool' tests property
-
-    [<Extension>]
-    static member Check (property : Property<bool>, tests : int<tests>, maxShrinks : int<shrinks>) : unit =
-        Property.checkBool'' tests maxShrinks property
-
-    [<Extension>]
-    static member Recheck (property : Property, size : Size, seed : Seed) : unit =
-        let (Property property) = property
-        Property.recheck size seed property
-
-    [<Extension>]
-    static member Recheck (property : Property, size : Size, seed : Seed, tests : int<tests>) : unit =
-        let (Property property) = property
-        Property.recheck' size seed tests property
-
-    [<Extension>]
-    static member Recheck (property : Property<bool>, size : Size, seed : Seed) : unit =
-        Property.recheckBool size seed property
-
-    [<Extension>]
-    static member Recheck (property : Property<bool>, size : Size, seed : Seed, tests : int<tests>) : unit =
-        Property.recheckBool' size seed tests property
-
-    [<Extension>]
-    static member ReportRecheck (property : Property, size : Size, seed : Seed) : Report =
-        let (Property property) = property
-        Property.reportRecheck size seed property
-
-    [<Extension>]
-    static member ReportRecheck (property : Property, size : Size, seed : Seed, tests : int<tests>) : Report =
-        let (Property property) = property
-        Property.reportRecheck' size seed tests property
-
-    [<Extension>]
-    static member ReportRecheck (property : Property<bool>, size : Size, seed : Seed) : Report =
-        Property.reportRecheckBool size seed property
-
-    [<Extension>]
-    static member ReportRecheck (property : Property<bool>, size : Size, seed : Seed, tests : int<tests>) : Report =
-        Property.reportRecheckBool' size seed tests property
-
-    [<Extension>]
-    static member Print (property : Property, tests : int<tests>) : unit =
-        let (Property property) = property
-        Property.print' tests property
+    static member ReportRecheck
+        (   property : Property<bool>,
+            size : Size,
+            seed : Seed,
+            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
+        ) : Report =
+        Property.reportRecheckBoolWith size seed (Build.config tests shrinkLimit) property
 
     [<Extension>]
     static member Print (property : Property) : unit =

--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -35,7 +35,7 @@ type PropertyConfigExtensions private () =
 type PropertyConfig =
 
     /// The default configuration for a property test.
-    static member DefaultConfig : Hedgehog.PropertyConfig =
+    static member Default : Hedgehog.PropertyConfig =
         PropertyConfig.defaultConfig
 
         

--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -100,7 +100,7 @@ type PropertyExtensions private () =
     [<Extension>]
     static member Check
         (   property : Property<bool>,
-            [<Optional; DefaultParameterValue null>] ?tests : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
             [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
         ) : unit =
         Property.checkBoolWith (Build.config tests shrinkLimit) property
@@ -148,9 +148,21 @@ type PropertyExtensions private () =
         Property.reportRecheckBoolWith size seed (Build.config tests shrinkLimit) property
 
     [<Extension>]
-    static member Print (property : Property) : unit =
+    static member Print
+        (   property : Property,
+            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
+        ) : unit =
         let (Property property) = property
-        Property.print property
+        Property.printWith (Build.config tests shrinkLimit) property
+
+    [<Extension>]
+    static member Print
+        (   property : Property<bool>,
+            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
+        ) : unit =
+        Property.printBoolWith (Build.config tests shrinkLimit) property
 
     [<Extension>]
     static member Where (property : Property<'T>, filter : Func<'T, bool>) : Property<'T> =

--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -21,12 +21,17 @@ module internal Build =
 [<AbstractClass; Sealed>]
 type PropertyConfigExtensions private () =
 
-    /// The number of shrinks to try before giving up on shrinking.
+    /// Set the number of times a property is allowed to shrink before the test runner gives up and prints the counterexample.
     [<Extension>]
     static member WithShrinkLimit (config : PropertyConfig, shrinkLimit: int<shrinks>) : PropertyConfig =
         PropertyConfig.withShrinkLimit shrinkLimit config
 
-    /// The number of successful tests that need to be run before a property test is considered successful.
+    /// Restores the default shrinking behavior.
+    [<Extension>]
+    static member WithoutShrinkLimit (config : PropertyConfig) : PropertyConfig =
+        PropertyConfig.withoutShrinkLimit config
+
+    /// Set the number of times a property should be executed before it is considered successful.
     [<Extension>]
     static member WithTestLimit (config : PropertyConfig, tests: int<tests>) : PropertyConfig =
         PropertyConfig.withTestLimit tests config

--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -8,9 +8,9 @@ open Hedgehog
 open System.Runtime.InteropServices
 
 module internal Build =
-    let config tests shrinkLimit =
+    let config testLimit shrinkLimit =
         PropertyConfig.defaultConfig
-        |> PropertyConfig.withTests (tests |> Option.defaultValue PropertyConfig.defaultConfig.TestLimit)
+        |> PropertyConfig.withTests (testLimit |> Option.defaultValue PropertyConfig.defaultConfig.TestLimit)
         |> fun config ->
             match shrinkLimit with
             | Some shrinkLimit -> config |> PropertyConfig.withShrinks shrinkLimit
@@ -33,8 +33,8 @@ type PropertyConfigExtensions private () =
 
     /// Set the number of times a property should be executed before it is considered successful.
     [<Extension>]
-    static member WithTests (config : PropertyConfig, tests: int<tests>) : PropertyConfig =
-        PropertyConfig.withTests tests config
+    static member WithTests (config : PropertyConfig, testLimit: int<tests>) : PropertyConfig =
+        PropertyConfig.withTests testLimit config
 
 
 type PropertyConfig =
@@ -119,19 +119,19 @@ type PropertyExtensions private () =
     [<Extension>]
     static member Check
         (   property : Property,
-            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
             [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
         ) : unit =
         let (Property property) = property
-        Property.checkWith (Build.config tests shrinkLimit) property
+        Property.checkWith (Build.config testLimit shrinkLimit) property
 
     [<Extension>]
     static member Check
         (   property : Property<bool>,
-            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
             [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
         ) : unit =
-        Property.checkBoolWith (Build.config tests shrinkLimit) property
+        Property.checkBoolWith (Build.config testLimit shrinkLimit) property
 
     [<Extension>]
     static member Check (property : Property, config : Hedgehog.PropertyConfig) : unit =
@@ -147,21 +147,21 @@ type PropertyExtensions private () =
         (   property : Property,
             size : Size,
             seed : Seed,
-            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
             [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
         ) : unit =
         let (Property property) = property
-        Property.recheckWith size seed (Build.config tests shrinkLimit) property
+        Property.recheckWith size seed (Build.config testLimit shrinkLimit) property
 
     [<Extension>]
     static member Recheck
         (   property : Property<bool>,
             size : Size,
             seed : Seed,
-            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
             [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
         ) : unit =
-        Property.recheckBoolWith size seed (Build.config tests shrinkLimit) property
+        Property.recheckBoolWith size seed (Build.config testLimit shrinkLimit) property
 
     [<Extension>]
     static member Recheck (property : Property, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : unit =
@@ -177,21 +177,21 @@ type PropertyExtensions private () =
         (   property : Property,
             size : Size,
             seed : Seed,
-            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
             [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
         ) : Report =
         let (Property property) = property
-        Property.reportRecheckWith size seed (Build.config tests shrinkLimit) property
+        Property.reportRecheckWith size seed (Build.config testLimit shrinkLimit) property
 
     [<Extension>]
     static member ReportRecheck
         (   property : Property<bool>,
             size : Size,
             seed : Seed,
-            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
             [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
         ) : Report =
-        Property.reportRecheckBoolWith size seed (Build.config tests shrinkLimit) property
+        Property.reportRecheckBoolWith size seed (Build.config testLimit shrinkLimit) property
 
     [<Extension>]
     static member ReportRecheck (property : Property, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : Report =
@@ -205,19 +205,19 @@ type PropertyExtensions private () =
     [<Extension>]
     static member Print
         (   property : Property,
-            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
             [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
         ) : unit =
         let (Property property) = property
-        Property.printWith (Build.config tests shrinkLimit) property
+        Property.printWith (Build.config testLimit shrinkLimit) property
 
     [<Extension>]
     static member Print
         (   property : Property<bool>,
-            [<Optional; DefaultParameterValue null>] ?tests       : int<tests>,
+            [<Optional; DefaultParameterValue null>] ?testLimit   : int<tests>,
             [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
         ) : unit =
-        Property.printBoolWith (Build.config tests shrinkLimit) property
+        Property.printBoolWith (Build.config testLimit shrinkLimit) property
 
     [<Extension>]
     static member Where (property : Property<'T>, filter : Func<'T, bool>) : Property<'T> =

--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -16,6 +16,29 @@ module internal Build =
             | Some shrinkLimit -> config |> PropertyConfig.withShrinkLimit shrinkLimit
             | None -> config
 
+
+[<Extension>]
+[<AbstractClass; Sealed>]
+type PropertyConfigExtensions private () =
+
+    /// The number of shrinks to try before giving up on shrinking.
+    [<Extension>]
+    static member WithShrinkLimit (config : PropertyConfig, shrinkLimit: int<shrinks>) : PropertyConfig =
+        PropertyConfig.withShrinkLimit shrinkLimit config
+
+    /// The number of successful tests that need to be run before a property test is considered successful.
+    [<Extension>]
+    static member WithTestCount (config : PropertyConfig, tests: int<tests>) : PropertyConfig =
+        PropertyConfig.withTestCount tests config
+
+
+type PropertyConfig =
+
+    /// The default configuration for a property test.
+    static member DefaultConfig : Hedgehog.PropertyConfig =
+        PropertyConfig.defaultConfig
+
+        
 type Property = private Property of Property<unit> with
 
     static member Failure : Property =
@@ -106,6 +129,15 @@ type PropertyExtensions private () =
         Property.checkBoolWith (Build.config tests shrinkLimit) property
 
     [<Extension>]
+    static member Check (property : Property, config : Hedgehog.PropertyConfig) : unit =
+        let (Property property) = property
+        Property.checkWith config property
+
+    [<Extension>]
+    static member Check (property : Property<bool>, config : Hedgehog.PropertyConfig) : unit =
+        Property.checkBoolWith config property
+
+    [<Extension>]
     static member Recheck
         (   property : Property,
             size : Size,
@@ -127,6 +159,15 @@ type PropertyExtensions private () =
         Property.recheckBoolWith size seed (Build.config tests shrinkLimit) property
 
     [<Extension>]
+    static member Recheck (property : Property, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : unit =
+        let (Property property) = property
+        Property.recheckWith size seed config property
+
+    [<Extension>]
+    static member Recheck (property : Property<bool>, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : unit =
+        Property.recheckBoolWith size seed config property
+
+    [<Extension>]
     static member ReportRecheck
         (   property : Property,
             size : Size,
@@ -146,6 +187,15 @@ type PropertyExtensions private () =
             [<Optional; DefaultParameterValue null>] ?shrinkLimit : int<shrinks>
         ) : Report =
         Property.reportRecheckBoolWith size seed (Build.config tests shrinkLimit) property
+
+    [<Extension>]
+    static member ReportRecheck (property : Property, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : Report =
+        let (Property property) = property
+        Property.reportRecheckWith size seed config property
+
+    [<Extension>]
+    static member ReportRecheck (property : Property<bool>, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : Report =
+        Property.reportRecheckBoolWith size seed config property
 
     [<Extension>]
     static member Print

--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -75,6 +75,11 @@ type PropertyExtensions private () =
         Property.report property
 
     [<Extension>]
+    static member Report (property : Property, tests : int<tests>, maxShrinks : int<shrinks>) : Report =
+        let (Property property) = property
+        Property.report'' tests maxShrinks property
+
+    [<Extension>]
     static member Report (property : Property, tests : int<tests>) : Report =
         let (Property property) = property
         Property.report' tests property
@@ -88,9 +93,18 @@ type PropertyExtensions private () =
         Property.reportBool' tests property
 
     [<Extension>]
+    static member Report (property : Property<bool>, tests : int<tests>, maxShrinks : int<shrinks>) : Report =
+        Property.reportBool'' tests maxShrinks property
+
+    [<Extension>]
     static member Check (property : Property) : unit =
         let (Property property) = property
         Property.check property
+
+    [<Extension>]
+    static member Check (property : Property, tests : int<tests>, maxShrinks : int<shrinks>) : unit =
+        let (Property property) = property
+        Property.check'' tests maxShrinks property
 
     [<Extension>]
     static member Check (property : Property, tests : int<tests>) : unit =
@@ -104,6 +118,10 @@ type PropertyExtensions private () =
     [<Extension>]
     static member Check (property : Property<bool>, tests : int<tests>) : unit =
         Property.checkBool' tests property
+
+    [<Extension>]
+    static member Check (property : Property<bool>, tests : int<tests>, maxShrinks : int<shrinks>) : unit =
+        Property.checkBool'' tests maxShrinks property
 
     [<Extension>]
     static member Recheck (property : Property, size : Size, seed : Seed) : unit =

--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -10,7 +10,7 @@ open System.Runtime.InteropServices
 module internal Build =
     let config tests shrinkLimit =
         PropertyConfig.defaultConfig
-        |> PropertyConfig.withTestCount (tests |> Option.defaultValue PropertyConfig.defaultConfig.TestCount)
+        |> PropertyConfig.withTestLimit (tests |> Option.defaultValue PropertyConfig.defaultConfig.TestLimit)
         |> fun config ->
             match shrinkLimit with
             | Some shrinkLimit -> config |> PropertyConfig.withShrinkLimit shrinkLimit
@@ -28,8 +28,8 @@ type PropertyConfigExtensions private () =
 
     /// The number of successful tests that need to be run before a property test is considered successful.
     [<Extension>]
-    static member WithTestCount (config : PropertyConfig, tests: int<tests>) : PropertyConfig =
-        PropertyConfig.withTestCount tests config
+    static member WithTestLimit (config : PropertyConfig, tests: int<tests>) : PropertyConfig =
+        PropertyConfig.withTestLimit tests config
 
 
 type PropertyConfig =

--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -10,10 +10,10 @@ open System.Runtime.InteropServices
 module internal Build =
     let config tests shrinkLimit =
         PropertyConfig.defaultConfig
-        |> PropertyConfig.withTestLimit (tests |> Option.defaultValue PropertyConfig.defaultConfig.TestLimit)
+        |> PropertyConfig.withTests (tests |> Option.defaultValue PropertyConfig.defaultConfig.TestLimit)
         |> fun config ->
             match shrinkLimit with
-            | Some shrinkLimit -> config |> PropertyConfig.withShrinkLimit shrinkLimit
+            | Some shrinkLimit -> config |> PropertyConfig.withShrinks shrinkLimit
             | None -> config
 
 
@@ -23,18 +23,18 @@ type PropertyConfigExtensions private () =
 
     /// Set the number of times a property is allowed to shrink before the test runner gives up and prints the counterexample.
     [<Extension>]
-    static member WithShrinkLimit (config : PropertyConfig, shrinkLimit: int<shrinks>) : PropertyConfig =
-        PropertyConfig.withShrinkLimit shrinkLimit config
+    static member WithShrinks (config : PropertyConfig, shrinkLimit: int<shrinks>) : PropertyConfig =
+        PropertyConfig.withShrinks shrinkLimit config
 
     /// Restores the default shrinking behavior.
     [<Extension>]
-    static member WithoutShrinkLimit (config : PropertyConfig) : PropertyConfig =
-        PropertyConfig.withoutShrinkLimit config
+    static member WithoutShrinks (config : PropertyConfig) : PropertyConfig =
+        PropertyConfig.withoutShrinks config
 
     /// Set the number of times a property should be executed before it is considered successful.
     [<Extension>]
-    static member WithTestLimit (config : PropertyConfig, tests: int<tests>) : PropertyConfig =
-        PropertyConfig.withTestLimit tests config
+    static member WithTests (config : PropertyConfig, tests: int<tests>) : PropertyConfig =
+        PropertyConfig.withTests tests config
 
 
 type PropertyConfig =

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -18,7 +18,8 @@ module PropertyConfig =
         { TestLimit = 100<tests>
           ShrinkLimit = None }
 
-    /// Set the number of times a property is allowed to shrink before the test runner gives up and prints the counterexample.
+    /// Set the number of times a property is allowed to shrink before the test
+    /// runner gives up and prints the counterexample.
     let withShrinks (shrinkLimit : int<shrinks>) (config : PropertyConfig) : PropertyConfig =
         { config with ShrinkLimit = Some shrinkLimit }
 
@@ -26,7 +27,8 @@ module PropertyConfig =
     let withoutShrinks (config : PropertyConfig) : PropertyConfig =
         { config with ShrinkLimit = None }
 
-    /// Set the number of times a property should be executed before it is considered successful.
+    /// Set the number of times a property should be executed before it is
+    /// considered successful.
     let withTests (testLimit : int<tests>) (config : PropertyConfig) : PropertyConfig =
         { config with TestLimit = testLimit }
 

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -6,19 +6,17 @@ open System
 type Property<'a> =
     | Property of Gen<Journal * Outcome<'a>>
 
-
 type PropertyConfig = internal {
     TestLimit : int<tests>
     ShrinkLimit : int<shrinks> option
 }
 
-
 module PropertyConfig =
 
     /// The default configuration for a property test.
     let defaultConfig : PropertyConfig =
-        {   TestLimit = 100<tests>
-            ShrinkLimit = None }
+        { TestLimit = 100<tests>
+          ShrinkLimit = None }
 
     /// Set the number of times a property is allowed to shrink before the test runner gives up and prints the counterexample.
     let withShrinks (shrinkLimit : int<shrinks>) (config : PropertyConfig) : PropertyConfig =
@@ -31,7 +29,6 @@ module PropertyConfig =
     /// Set the number of times a property should be executed before it is considered successful.
     let withTests (testLimit : int<tests>) (config : PropertyConfig) : PropertyConfig =
         { config with TestLimit = testLimit }
-
 
 module Property =
 
@@ -130,7 +127,7 @@ module Property =
             (size : Size)
             (seed : Seed)
             (Node ((journal, x), xs) : Tree<Journal * Outcome<'a>>)
-            (nshrinks : int<shrinks>) 
+            (nshrinks : int<shrinks>)
             (shrinkLimit : int<shrinks> Option) : Status =
         let failed =
             Failed {

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -14,6 +14,7 @@ type PropertyConfig = internal {
 
 
 module PropertyConfig =
+
     /// The default configuration for a property test.
     let defaultConfig : PropertyConfig =
         {   TestLimit = 100<tests>
@@ -186,18 +187,15 @@ module Property =
 
         loop seed size0 0<tests> 0<discards>
 
-    let private reportWith (renderRecheck : bool) (size : Size) (seed : Seed) (p : Property<unit>) : Report =
-        p |> reportWith' renderRecheck size seed 100<tests>
-
-    let report' (n : int<tests>) (p : Property<unit>) : Report =
+    let reportWith (config : PropertyConfig) (p : Property<unit>) : Report =
         let seed = Seed.random ()
-        p |> reportWith' true 1 seed n
+        p |> reportWith' true 1 seed config
 
     let report (p : Property<unit>) : Report =
-        p |> report' 100<tests>
+        p |> reportWith PropertyConfig.defaultConfig
 
-    let reportBool' (n : int<tests>) (p : Property<bool>) : Report =
-        p |> bind ofBool |> report' n
+    let reportBoolWith (config : PropertyConfig) (p : Property<bool>) : Report =
+        p |> bind ofBool |> reportWith config
 
     let reportBool (p : Property<bool>) : Report =
         p |> bind ofBool |> report
@@ -213,8 +211,8 @@ module Property =
     let checkBool (g : Property<bool>) : unit =
         g |> bind ofBool |> check
 
-    let checkBool' (n : int<tests>) (g : Property<bool>) : unit =
-        g |> bind ofBool |> check' n
+    let checkBoolWith (config : PropertyConfig) (g : Property<bool>) : unit =
+        g |> bind ofBool |> checkWith config
 
     /// Converts a possibly-throwing function to
     /// a property by treating "no exception" as success.
@@ -231,8 +229,8 @@ module Property =
     let reportRecheck (size : Size) (seed : Seed) (p : Property<unit>) : Report =
         reportWith' false size seed PropertyConfig.defaultConfig p
 
-    let reportRecheckBool' (size : Size) (seed : Seed) (n : int<tests>) (p : Property<bool>) : Report =
-        p |> bind ofBool |> reportRecheck' size seed n
+    let reportRecheckBoolWith (size : Size) (seed : Seed) (config : PropertyConfig) (p : Property<bool>) : Report =
+        p |> bind ofBool |> reportRecheckWith size seed config
 
     let reportRecheckBool (size : Size) (seed : Seed) (p : Property<bool>) : Report =
         p |> bind ofBool |> reportRecheck size seed
@@ -245,8 +243,8 @@ module Property =
         reportRecheck size seed p
         |> Report.tryRaise
 
-    let recheckBool' (size : Size) (seed : Seed) (n : int<tests>) (g : Property<bool>) : unit =
-        g |> bind ofBool |> recheck' size seed n
+    let recheckBoolWith (size : Size) (seed : Seed) (config : PropertyConfig) (g : Property<bool>) : unit =
+        g |> bind ofBool |> recheckWith size seed config
 
     let recheckBool (size : Size) (seed : Seed) (g : Property<bool>) : unit =
         g |> bind ofBool |> recheck size seed

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -8,7 +8,7 @@ type Property<'a> =
 
 
 type PropertyConfig = internal {
-    TestCount : int<tests>
+    TestLimit : int<tests>
     ShrinkLimit : int<shrinks> option
 }
 
@@ -16,7 +16,7 @@ type PropertyConfig = internal {
 module PropertyConfig =
     /// The default configuration for a property test.
     let defaultConfig : PropertyConfig =
-        {   TestCount = 100<tests>
+        {   TestLimit = 100<tests>
             ShrinkLimit = None }
 
     /// The number of shrinks to try before giving up on shrinking.
@@ -24,8 +24,8 @@ module PropertyConfig =
         { config with ShrinkLimit = Some shrinkLimit }
 
     /// The number of successful tests that need to be run before a property test is considered successful.
-    let withTestCount (testCount : int<tests>) (config : PropertyConfig) : PropertyConfig =
-        { config with TestCount = testCount }
+    let withTestLimit (testLimit : int<tests>) (config : PropertyConfig) : PropertyConfig =
+        { config with TestLimit = testLimit }
 
 
 module Property =
@@ -159,7 +159,7 @@ module Property =
                 size + 1
 
         let rec loop seed size tests discards =
-            if tests = config.TestCount then
+            if tests = config.TestLimit then
                 { Tests = tests
                   Discards = discards
                   Status = OK }

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -1,4 +1,4 @@
-﻿namespace Hedgehog
+namespace Hedgehog
 
 open System
 
@@ -8,21 +8,24 @@ type Property<'a> =
 
 
 type PropertyConfig = internal {
-    TestCount   : int<tests>
+    TestCount : int<tests>
     ShrinkLimit : int<shrinks> option
 }
 
 
 module PropertyConfig =
-    let defaultConfig =
+    /// The default configuration for a property test.
+    let defaultConfig : PropertyConfig =
         {   TestCount = 100<tests>
             ShrinkLimit = None }
 
-    let withShrinkLimit shrinkLimit c =
-        { c with ShrinkLimit = Some shrinkLimit }
+    /// The number of shrinks to try before giving up on shrinking.
+    let withShrinkLimit (shrinkLimit : int<shrinks>) (config : PropertyConfig) : PropertyConfig =
+        { config with ShrinkLimit = Some shrinkLimit }
 
-    let withTestCount testCount c =
-        { c with TestCount = testCount }
+    /// The number of successful tests that need to be run before a property test is considered successful.
+    let withTestCount (testCount : int<tests>) (config : PropertyConfig) : PropertyConfig =
+        { config with TestCount = testCount }
 
 
 module Property =

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -20,11 +20,15 @@ module PropertyConfig =
         {   TestLimit = 100<tests>
             ShrinkLimit = None }
 
-    /// The number of shrinks to try before giving up on shrinking.
+    /// Set the number of times a property is allowed to shrink before the test runner gives up and prints the counterexample.
     let withShrinkLimit (shrinkLimit : int<shrinks>) (config : PropertyConfig) : PropertyConfig =
         { config with ShrinkLimit = Some shrinkLimit }
 
-    /// The number of successful tests that need to be run before a property test is considered successful.
+    /// Restores the default shrinking behavior.
+    let withoutShrinkLimit (config : PropertyConfig) : PropertyConfig =
+        { config with ShrinkLimit = None }
+
+    /// Set the number of times a property should be executed before it is considered successful.
     let withTestLimit (testLimit : int<tests>) (config : PropertyConfig) : PropertyConfig =
         { config with TestLimit = testLimit }
 

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -100,26 +100,34 @@ module Property =
             (size : Size)
             (seed : Seed)
             (Node ((journal, x), xs) : Tree<Journal * Outcome<'a>>)
-            (nshrinks : int<shrinks>) : Status =
+            (nshrinks : int<shrinks>) 
+            (maxShrinks : int<shrinks> Option) : Status =
+        let failed =
+            Failed {
+                Size = size
+                Seed = seed
+                Shrinks = nshrinks
+                Journal = journal
+                RenderRecheck = renderRecheck
+            }
+        let takeSmallest tree = takeSmallest renderRecheck size seed tree (nshrinks + 1<shrinks>) maxShrinks
         match x with
         | Failure ->
             match Seq.tryFind (Outcome.isFailure << snd << Tree.outcome) xs with
-            | None ->
-                Failed {
-                    Size = size
-                    Seed = seed
-                    Shrinks = nshrinks
-                    Journal = journal
-                    RenderRecheck = renderRecheck
-                }
+            | None -> failed
             | Some tree ->
-                takeSmallest renderRecheck size seed tree (nshrinks + 1<shrinks>)
+                match maxShrinks with
+                | None -> takeSmallest tree
+                | Some maxShrinks' ->
+                    if nshrinks < maxShrinks' then
+                        takeSmallest tree
+                    else failed
         | Discard ->
             GaveUp
         | Success _ ->
             OK
 
-    let private reportWith' (renderRecheck : bool) (size0 : Size) (seed : Seed) (n : int<tests>) (p : Property<unit>) : Report =
+    let private reportWith' (renderRecheck : bool) (size0 : Size) (seed : Seed) (n : int<tests>) maxShrinks (p : Property<unit>) : Report =
         let random = toGen p |> Gen.toRandom
 
         let nextSize size =
@@ -145,7 +153,7 @@ module Property =
                 | Failure ->
                     { Tests = tests + 1<tests>
                       Discards = discards
-                      Status = takeSmallest renderRecheck size seed result 0<shrinks> }
+                      Status = takeSmallest renderRecheck size seed result 0<shrinks> maxShrinks}
                 | Success () ->
                     loop seed2 (nextSize size) (tests + 1<tests>) discards
                 | Discard ->
@@ -153,15 +161,22 @@ module Property =
 
         loop seed size0 0<tests> 0<discards>
 
-    let private reportWith (renderRecheck : bool) (size : Size) (seed : Seed) (p : Property<unit>) : Report =
-        reportWith' renderRecheck size seed 100<tests> p
+    let private reportWith (renderRecheck : bool) (size : Size) (seed : Seed) maxShrinks (p : Property<unit>) : Report =
+        reportWith' renderRecheck size seed 100<tests> maxShrinks p
+
+    let report'' (n : int<tests>) (maxShrinks : int<shrinks>) (p : Property<unit>) : Report =
+        let seed = Seed.random ()
+        reportWith' true 1 seed n (Some maxShrinks) p
 
     let report' (n : int<tests>) (p : Property<unit>) : Report =
         let seed = Seed.random ()
-        reportWith' true 1 seed n p
+        reportWith' true 1 seed n None p
 
     let report (p : Property<unit>) : Report =
         report' 100<tests> p
+
+    let reportBool'' (n : int<tests>) (maxShrinks : int<shrinks>) (p : Property<bool>) : Report =
+        bind p ofBool |> report'' n maxShrinks
 
     let reportBool' (n : int<tests>) (p : Property<bool>) : Report =
         bind p ofBool |> report' n
@@ -169,12 +184,20 @@ module Property =
     let reportBool (p : Property<bool>) : Report =
         bind p ofBool |> report
 
+    let check'' (n : int<tests>) (maxShrinks : int<shrinks>) (p : Property<unit>) : unit =
+        report'' n maxShrinks p
+        |> Report.tryRaise
+
     let check' (n : int<tests>) (p : Property<unit>) : unit =
         report' n p
         |> Report.tryRaise
 
     let check (p : Property<unit>) : unit =
         report p
+        |> Report.tryRaise
+
+    let checkBool'' (n : int<tests>) (maxShrinks : int<shrinks>) (p : Property<bool>) : unit =
+        reportBool'' n maxShrinks p
         |> Report.tryRaise
 
     let checkBool (g : Property<bool>) : unit =
@@ -193,10 +216,10 @@ module Property =
         | _ -> failure
 
     let reportRecheck' (size : Size) (seed : Seed) (n : int<tests>) (p : Property<unit>) : Report =
-        reportWith' false size seed n p
+        reportWith' false size seed n None p
 
     let reportRecheck (size : Size) (seed : Seed) (p : Property<unit>) : Report =
-        reportWith false size seed p
+        reportWith false size seed None p
 
     let reportRecheckBool' (size : Size) (seed : Seed) (n : int<tests>) (p : Property<bool>) : Report =
         bind p ofBool |> reportRecheck' size seed n

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -252,6 +252,16 @@ module Property =
         |> Report.render
         |> printfn "%s"
 
+    let printBoolWith (config : PropertyConfig) (p : Property<bool>) : unit =
+        reportBoolWith config p
+        |> Report.render
+        |> printfn "%s"
+
+    let printBool (p : Property<bool>) : unit =
+        reportBool p
+        |> Report.render
+        |> printfn "%s"
+
 [<AutoOpen>]
 module PropertyBuilder =
     let rec private loop (p : unit -> bool) (m : Property<unit>) : Property<unit> =

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -21,15 +21,15 @@ module PropertyConfig =
             ShrinkLimit = None }
 
     /// Set the number of times a property is allowed to shrink before the test runner gives up and prints the counterexample.
-    let withShrinkLimit (shrinkLimit : int<shrinks>) (config : PropertyConfig) : PropertyConfig =
+    let withShrinks (shrinkLimit : int<shrinks>) (config : PropertyConfig) : PropertyConfig =
         { config with ShrinkLimit = Some shrinkLimit }
 
     /// Restores the default shrinking behavior.
-    let withoutShrinkLimit (config : PropertyConfig) : PropertyConfig =
+    let withoutShrinks (config : PropertyConfig) : PropertyConfig =
         { config with ShrinkLimit = None }
 
     /// Set the number of times a property should be executed before it is considered successful.
-    let withTestLimit (testLimit : int<tests>) (config : PropertyConfig) : PropertyConfig =
+    let withTests (testLimit : int<tests>) (config : PropertyConfig) : PropertyConfig =
         { config with TestLimit = testLimit }
 
 

--- a/src/Hedgehog/Script.fsx
+++ b/src/Hedgehog/Script.fsx
@@ -3,12 +3,14 @@
       "Numeric.fs"
       "Seed.fs"
       "Tree.fs"
+      "OptionTree.fs"
       "Range.fs"
       "Random.fs"
       "Shrink.fs"
       "Gen.fs"
       "Journal.fs"
       "Tuple.fs"
+      "GenTuple.fs"
       "Outcome.fs"
       "Report.fs"
       "Property.fs"
@@ -220,6 +222,9 @@ let shrinkExp = function
         [x; y]
 
 #nowarn "40"
+
+open Hedgehog.Gen.Operators
+
 let rec genExp =
     Gen.delay (fun _ ->
         let choiceRec =

--- a/tests/Hedgehog.Linq.Tests/LinqTests.cs
+++ b/tests/Hedgehog.Linq.Tests/LinqTests.cs
@@ -87,7 +87,7 @@ namespace Hedgehog.Linq.Tests
                 where y == false
                 select Assert.True(x && !y);
 
-            property.Check(20);
+            property.Check(PropertyConfig.Default.WithTests(20));
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace Hedgehog.Linq.Tests
                 where y == false
                 select x && !y;
 
-            property.Check(20);
+            property.Check(PropertyConfig.Default.WithTests(20));
         }
 
         [Fact]

--- a/tests/Hedgehog.Tests/ShrinkTests.fs
+++ b/tests/Hedgehog.Tests/ShrinkTests.fs
@@ -237,13 +237,16 @@ let ``towardsDouble returns empty list when run out of shrinks`` x0 destination 
 [<InlineData(0)>]
 [<InlineData(1)>]
 [<InlineData(2)>]
-let ``Property.report'' respects its maxShrinks`` maxShrinks =
+let ``Property.reportWith respects shrinkLimit`` shrinkLimit =
+    let propConfig =
+        PropertyConfig.defaultConfig
+        |> PropertyConfig.withShrinkLimit shrinkLimit
     let report =
         property {
             let! actual = Range.linear 1 1_000_000 |> Gen.int
             return actual < 500_000
-        } |> Property.report'' 100<tests> maxShrinks
+        } |> Property.reportWith propConfig
     match report.Status with
     | Failed failureData ->
-        failureData.Shrinks =! maxShrinks
+        failureData.Shrinks =! shrinkLimit
     | _ -> failwith "impossible"

--- a/tests/Hedgehog.Tests/ShrinkTests.fs
+++ b/tests/Hedgehog.Tests/ShrinkTests.fs
@@ -240,7 +240,7 @@ let ``towardsDouble returns empty list when run out of shrinks`` x0 destination 
 let ``Property.reportWith respects shrinkLimit`` shrinkLimit =
     let propConfig =
         PropertyConfig.defaultConfig
-        |> PropertyConfig.withShrinkLimit shrinkLimit
+        |> PropertyConfig.withShrinks shrinkLimit
     let report =
         property {
             let! actual = Range.linear 1 1_000_000 |> Gen.int

--- a/tests/Hedgehog.Tests/ShrinkTests.fs
+++ b/tests/Hedgehog.Tests/ShrinkTests.fs
@@ -232,3 +232,18 @@ let ``towardsDouble returns empty list when run out of shrinks`` x0 destination 
         |> Shrink.towards destination
         |> Seq.toList
     test <@ actual |> List.isEmpty @>
+
+[<Theory>]
+[<InlineData(0)>]
+[<InlineData(1)>]
+[<InlineData(2)>]
+let ``Property.report'' respects its maxShrinks`` maxShrinks =
+    let report =
+        property {
+            let! actual = Range.linear 1 1_000_000 |> Gen.int
+            return actual < 500_000
+        } |> Property.report'' 100<tests> maxShrinks
+    match report.Status with
+    | Failed failureData ->
+        failureData.Shrinks =! maxShrinks
+    | _ -> failwith "impossible"


### PR DESCRIPTION
Sometimes I don't want Hedgehog to shrink. For example, if I'm writing an [integration test with a temporary database](https://jacobstanley.io/how-to-use-hedgehog-to-test-a-real-world-large-scale-stateful-app/), it takes several seconds to spin up a new DB. When I'm in the initial stages of RedGreenRefactor, there's a _lot_ of red. Often the first test will immediately fail, but it will incur ~30 shrinks because my datatypes aren't simple. Those shrinks become quite time-expensive for no real benefit.

This PR adds an `(maxShrinks : int<shrinks> option)` parameter to `takeSmallest` which controls how many times shrinking will occur. I also added `Property.check''` and friends. I'm not fond of the name... but I'm out of ideas.