### PR TITLE
Slightly improved docs

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -289,7 +289,7 @@ You can find out more about integrated vs type-based shrinking in [this](http://
 
 ### Generators
 
-Hedgehog's `Gen` module exports some basic generators and plenty combinators for making new generators. Here's a generator of alphanumeric chatracters:
+Hedgehog's `Gen` module exports some basic generators and plenty combinators for making new generators. Here's a generator of alphanumeric characters:
 
 ```fs
 Gen.alphaNum
@@ -346,7 +346,7 @@ Gen.alphaNum |> Gen.printSample;;
 
 #### 👉 Generators can also be created using the `gen` expression
 
-Hedgehog supports a convenient syntax for working with generators through the `gen` expression. Here's a way to define a generator of type System.Net.IPAddress:
+Hedgehog supports a convenient syntax for working with generators through the `gen` expression. Here's a way to define a generator of type `System.Net.IPAddress`:
 
 ```fs
 open System.Net
@@ -593,12 +593,15 @@ property {
 
 ```fs
 let g = Gen.list (Range.linear 0 100) Gen.alpha
+let propConfig =
+    PropertyConfig.defaultConfig
+    |> PropertyConfig.withTests 500<tests>
 
 property {
     let! xs = g
     return List.rev (List.rev xs) = xs
 }
-|> Property.print' 500<tests>;;
+|> Property.printWith propConfig;;
 
 >
 +++ OK, passed 500 tests.
@@ -621,7 +624,7 @@ property {
 
 ```
 
->Outside of F# Interactive, you might want to use `Property.check` or `Property.check'`, specially if you're using Unquote with xUnit, NUnit, MSTest, or similar.
+>Outside of F# Interactive, you might want to use `Property.check` or `Property.checkWith`, specially if you're using Unquote with xUnit, NUnit, MSTest, or similar.
 
 #### Try out (see it fail)
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -712,6 +712,40 @@ Use your favorite tools with Hedgehog.
 
 Powerful integrations that help you and your team build properties in an easier way.
 
+### Hedgehog.Experimental
+
+[Hedgehog.Experimental](https://github.com/hedgehogqa/fsharp-hedgehog-experimental) contains auto-generators, à la AutoFixture, as well as other convenient combinators.
+
+```fs
+// Can generate all F# types (unions, records, lists, etc.) as well as POCOs
+// with mutable properties or constructors.
+
+type Union =
+  | Husband of int
+  | Wife of string
+  
+type Record =
+  {Sport: string
+   Time: TimeSpan}
+   
+let! union = GenX.auto<Union>
+let! record = GenX.auto<Record>
+```
+
+### Hedgehog.Xunit
+
+[Hedgehog.Xunit](https://github.com/dharmaturtle/fsharp-hedgehog-xunit) provides attributes which make it simpler to write [xUnit.net](https://xunit.net/) tests.
+
+Our very first test may be reinterpreted as
+
+```fs
+[<Property>]
+let ``Reversing a list twice yields the original list`` (xs: int list) =
+    List.rev (List.rev xs) = xs
+```
+
+Arguments are generated with Hedgehog.Experimental.
+
 ### Regex-constrained strings
 
 In Haskell, there's the [quickcheck-regex](https://hackage.haskell.org/package/quickcheck-regex) package, by [Audrey (唐鳳) Tang](https://www.linkedin.com/in/tangaudrey), which allows to write and execute this:


### PR DESCRIPTION
I have no idea how the new fsdocs/gh-pages work, so here are some markdown edits. Perhaps we should wait until a release is cut before merging them though?

I'd like to make more drastic changes, but I'll wait until the fsdocs/gh-pages start to gain structure.

Also, there are many references to the "gen expression" and "property expression". Is there a reason why we aren't calling them "computation expressions"?

Also also, should we [disable the wiki](https://docs.github.com/en/github/building-a-strong-community/disabling-wikis) since we're going in the gh-pages direction?