### PR TITLE
Tidy up Numeric.fs

### DIFF
--- a/src/Hedgehog/Numeric.fs
+++ b/src/Hedgehog/Numeric.fs
@@ -177,10 +177,10 @@ type FromBigInt =
         id
 
     static member FromBigInt (_: uint8, _: FromBigInt) : bigint -> uint8 =
-        uint8 << int32
+        int32 >> uint8
 
     static member FromBigInt (_: uint16, _: FromBigInt) : bigint -> uint16 =
-        uint16 << int32
+        int32 >> uint16
 
     static member FromBigInt (_: uint32, _: FromBigInt) : bigint -> uint32 =
         uint32
@@ -189,10 +189,10 @@ type FromBigInt =
         uint64
 
     static member FromBigInt (_: int8, _: FromBigInt) : bigint -> int8 =
-        int8 << int32
+        int32 >> int8
 
     static member FromBigInt (_: int16, _: FromBigInt) : bigint -> int16 =
-        int16 << int32
+        int32 >> int16
 
     static member FromBigInt (_: int32, _: FromBigInt) : bigint -> int32 =
         int32
@@ -207,14 +207,14 @@ type FromBigInt =
         double
 
     static member FromBigInt (_: decimal, _: FromBigInt) : bigint -> decimal =
-        decimal << int32
+        int32 >> decimal
 
 #if !FABLE_COMPILER
     static member FromBigInt (_: nativeint , _: FromBigInt) : bigint -> nativeint =
-        nativeint << int32
+        int32 >> nativeint
 
     static member FromBigInt (_: unativeint, _: FromBigInt) : bigint -> unativeint =
-        unativeint << int32
+        int32 >> unativeint
 #endif
 
     static member inline Invoke (x: bigint) : 'Num =

--- a/src/Hedgehog/Numeric.fs
+++ b/src/Hedgehog/Numeric.fs
@@ -67,25 +67,25 @@ type MinValue =
             call2 (a, Unchecked.defaultof<'r>) : 'r
         call1 Unchecked.defaultof<MinValue>
 
-    static member inline MinValue ((_ : 'a * 'b), _ : MinValue) =
+    static member inline MinValue ((_: 'a * 'b), _: MinValue) =
         (MinValue.Invoke(), MinValue.Invoke())
 
-    static member inline MinValue ((_ : 'a * 'b * 'c), _ : MinValue) =
+    static member inline MinValue ((_: 'a * 'b * 'c), _: MinValue) =
         (MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke())
 
-    static member inline MinValue ((_ : 'a * 'b * 'c * 'd), _ : MinValue) =
+    static member inline MinValue ((_: 'a * 'b * 'c * 'd), _: MinValue) =
         (MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke())
 
-    static member inline MinValue ((_ : 'a * 'b * 'c * 'd * 'e), _ : MinValue) =
+    static member inline MinValue ((_: 'a * 'b * 'c * 'd * 'e), _: MinValue) =
         (MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke())
 
-    static member inline MinValue ((_ : 'a * 'b * 'c * 'd * 'e * 'f), _ : MinValue) =
+    static member inline MinValue ((_: 'a * 'b * 'c * 'd * 'e * 'f), _: MinValue) =
         (MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke())
 
-    static member inline MinValue ((_ : 'a * 'b * 'c * 'd * 'e * 'f * 'g), _ : MinValue) =
+    static member inline MinValue ((_: 'a * 'b * 'c * 'd * 'e * 'f * 'g), _: MinValue) =
         (MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke())
 
-    static member inline MinValue ((_ : 'a * 'b * 'c * 'd * 'e * 'f * 'g * 'h), _ : MinValue) =
+    static member inline MinValue ((_: 'a * 'b * 'c * 'd * 'e * 'f * 'g * 'h), _: MinValue) =
         (MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke())
 
 type MaxValue =
@@ -150,25 +150,25 @@ type MaxValue =
             call2 (a, Unchecked.defaultof<'r>) : 'r
         call1 Unchecked.defaultof<MaxValue>
 
-    static member inline MaxValue ((_ : 'a * 'b), _ : MaxValue) =
+    static member inline MaxValue ((_: 'a * 'b), _: MaxValue) =
         (MaxValue.Invoke(), MaxValue.Invoke())
 
-    static member inline MaxValue ((_ : 'a  *'b *'c), _ : MaxValue) =
+    static member inline MaxValue ((_: 'a  *'b *'c), _: MaxValue) =
         (MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke())
 
-    static member inline MaxValue ((_ : 'a *'b *'c *'d), _ : MaxValue) =
+    static member inline MaxValue ((_: 'a *'b *'c *'d), _: MaxValue) =
         (MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke())
 
-    static member inline MaxValue ((_ : 'a * 'b * 'c * 'd * 'e), _ : MaxValue) =
+    static member inline MaxValue ((_: 'a * 'b * 'c * 'd * 'e), _: MaxValue) =
         (MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke())
 
-    static member inline MaxValue ((_ : 'a * 'b * 'c * 'd *'e *'f), _ : MaxValue) =
+    static member inline MaxValue ((_: 'a * 'b * 'c * 'd *'e *'f), _: MaxValue) =
         (MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke())
 
-    static member inline MaxValue ((_ : 'a * 'b * 'c * 'd * 'e * 'f *'g), _ : MaxValue) =
+    static member inline MaxValue ((_: 'a * 'b * 'c * 'd * 'e * 'f *'g), _: MaxValue) =
         (MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke())
 
-    static member inline MaxValue ((_ : 'a * 'b * 'c * ' d *'e * 'f *'g *'h), _ : MaxValue) =
+    static member inline MaxValue ((_: 'a * 'b * 'c * ' d *'e * 'f *'g *'h), _: MaxValue) =
         (MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke())
 
 type FromBigInt =
@@ -230,10 +230,10 @@ type ToBigInt =
         x
 
     static member ToBigInt (x: uint8) : bigint =
-        bigint (int x)
+        bigint (int32 x)
 
     static member ToBigInt (x: uint16) : bigint =
-        bigint (int x)
+        bigint (int32 x)
 
     static member ToBigInt (x: uint32) : bigint =
         bigint x
@@ -242,10 +242,10 @@ type ToBigInt =
         bigint x
 
     static member ToBigInt (x: int8) : bigint =
-        bigint (int x)
+        bigint (int32 x)
 
     static member ToBigInt (x: int16) : bigint =
-        bigint (int x)
+        bigint (int32 x)
 
     static member ToBigInt (x: int32) : bigint =
         bigint x

--- a/src/Hedgehog/Numeric.fs
+++ b/src/Hedgehog/Numeric.fs
@@ -1,72 +1,71 @@
 ﻿namespace Hedgehog
 
-//
 // The handful of ad-hoc polymorphic things we need from FsControl, copied from
 // https://github.com/gmpl/FsControl/blob/f125b96d252080f722a1ff7a9efcfaf53420a339/FsControl.Core/Numeric.fs
-//
 
 open System
 
 type MinValue =
-    static member MinValue (_ : unit, _ : MinValue) =
+
+    static member MinValue (_: unit, _: MinValue) : unit =
         ()
 
-    static member MinValue (_ : bool, _ : MinValue) =
+    static member MinValue (_: bool, _: MinValue) : bool =
         false
 
-    static member MinValue (_ : char, _ : MinValue) =
+    static member MinValue (_: char, _: MinValue) : char =
         Char.MinValue
 
-    static member MinValue (_ : byte, _ : MinValue) =
+    static member MinValue (_: uint8, _: MinValue) : uint8 =
         Byte.MinValue
 
-    static member MinValue (_ : sbyte, _ : MinValue) =
-        SByte.MinValue
-
-    static member MinValue (_ : float, _ : MinValue) =
-        Double.MinValue
-
-    static member MinValue (_ : int16, _ : MinValue) =
-        Int16.MinValue
-
-    static member MinValue (_ : int, _ : MinValue) =
-        Int32.MinValue
-
-    static member MinValue (_ : int64, _ : MinValue) =
-        Int64.MinValue
-
-    static member MinValue (_ : float32, _ : MinValue) =
-        Single.MinValue
-
-    static member MinValue (_ : uint16, _ : MinValue) =
+    static member MinValue (_: uint16, _: MinValue) : uint16 =
         UInt16.MinValue
 
-    static member MinValue (_ : uint32, _ : MinValue) =
+    static member MinValue (_: uint32, _: MinValue) : uint32 =
         UInt32.MinValue
 
-    static member MinValue (_ : uint64, _ : MinValue) =
+    static member MinValue (_: uint64, _: MinValue) : uint64 =
         UInt64.MinValue
 
-    static member MinValue (_ : decimal, _ : MinValue) =
+    static member MinValue (_: int8, _: MinValue) : int8 =
+        SByte.MinValue
+
+    static member MinValue (_: int16, _: MinValue) : int16 =
+        Int16.MinValue
+
+    static member MinValue (_: int32, _: MinValue) : int32 =
+        Int32.MinValue
+
+    static member MinValue (_: int64, _: MinValue) : int64 =
+        Int64.MinValue
+
+    static member MinValue (_: single, _: MinValue) : single =
+        Single.MinValue
+
+    static member MinValue (_: double, _: MinValue) : double =
+        Double.MinValue
+
+    static member MinValue (_: decimal, _: MinValue) : decimal =
         Decimal.MinValue
 
-    static member MinValue (_ : DateTime, _ : MinValue) =
+    static member MinValue (_: DateTime, _: MinValue) : DateTime =
         DateTime.MinValue
 
-    static member MinValue (_ : DateTimeOffset, _ : MinValue) =
+    static member MinValue (_: DateTimeOffset, _: MinValue) : DateTimeOffset =
         DateTimeOffset.MinValue
 
 #if !FABLE_COMPILER
-    static member MinValue (_ : TimeSpan, _ : MinValue) =
+    static member MinValue (_: TimeSpan, _: MinValue) : TimeSpan =
         TimeSpan.MinValue
 #endif
 
     static member inline Invoke () =
-        let inline call_2 (a : ^a, b : ^b) =
-            ((^a or ^b) : (static member MinValue : _ * _ -> _) b, a)
-        let inline call (a : 'a) =
-            call_2 (a, Unchecked.defaultof<'r>) :'r
-        call Unchecked.defaultof<MinValue>
+        let inline call2 (a: ^a, b: ^b) =
+            ((^a or ^b): (static member MinValue: _ * _ -> _) b, a)
+        let inline call1 (a: 'a) =
+            call2 (a, Unchecked.defaultof<'r>) : 'r
+        call1 Unchecked.defaultof<MinValue>
 
     static member inline MinValue ((_ : 'a * 'b), _ : MinValue) =
         (MinValue.Invoke(), MinValue.Invoke())
@@ -90,65 +89,66 @@ type MinValue =
         (MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke(), MinValue.Invoke())
 
 type MaxValue =
-    static member MaxValue (_ : unit, _ : MaxValue) =
+
+    static member MaxValue (_: unit, _: MaxValue) : unit =
         ()
 
-    static member MaxValue (_ : bool, _ : MaxValue) =
+    static member MaxValue (_: bool, _: MaxValue) : bool =
         true
 
-    static member MaxValue (_ : char, _ :  MaxValue) =
+    static member MaxValue (_: char, _:  MaxValue) : char =
         Char.MaxValue
 
-    static member MaxValue (_ : byte, _ : MaxValue) =
+    static member MaxValue (_: uint8, _: MaxValue) : uint8 =
         Byte.MaxValue
 
-    static member MaxValue (_ : sbyte, _ : MaxValue) =
-        SByte.MaxValue
-
-    static member MaxValue (_ : float, _ : MaxValue) =
-        Double.MaxValue
-
-    static member MaxValue (_ : int16, _ : MaxValue) =
-        Int16.MaxValue
-
-    static member MaxValue (_ : int, _ : MaxValue) =
-        Int32.MaxValue
-
-    static member MaxValue (_ : int64, _ : MaxValue) =
-        Int64.MaxValue
-
-    static member MaxValue (_ : float32, _ : MaxValue) =
-        Single.MaxValue
-
-    static member MaxValue (_ : uint16, _ : MaxValue) =
+    static member MaxValue (_: uint16, _: MaxValue) : uint16 =
         UInt16.MaxValue
 
-    static member MaxValue (_ : uint32, _ : MaxValue) =
+    static member MaxValue (_: uint32, _: MaxValue) : uint32 =
         UInt32.MaxValue
 
-    static member MaxValue (_ : uint64, _ : MaxValue) =
+    static member MaxValue (_: uint64, _: MaxValue) : uint64 =
         UInt64.MaxValue
 
-    static member MaxValue (_ : decimal, _ : MaxValue) =
+    static member MaxValue (_: int8, _: MaxValue) : int8 =
+        SByte.MaxValue
+
+    static member MaxValue (_: int16, _: MaxValue) : int16 =
+        Int16.MaxValue
+
+    static member MaxValue (_: int32, _: MaxValue) : int32 =
+        Int32.MaxValue
+
+    static member MaxValue (_: int64, _: MaxValue) : int64 =
+        Int64.MaxValue
+
+    static member MaxValue (_: single, _: MaxValue) : single =
+        Single.MaxValue
+
+    static member MaxValue (_: double, _: MaxValue) : double =
+        Double.MaxValue
+
+    static member MaxValue (_: decimal, _: MaxValue) : decimal =
         Decimal.MaxValue
 
-    static member MaxValue (_ : DateTime, _ : MaxValue) =
+    static member MaxValue (_: DateTime, _: MaxValue) : DateTime =
         DateTime.MaxValue
 
-    static member MaxValue (_ : DateTimeOffset, _ : MaxValue) =
+    static member MaxValue (_: DateTimeOffset, _: MaxValue) : DateTimeOffset =
         DateTimeOffset.MaxValue
 
 #if !FABLE_COMPILER
-    static member MaxValue (_ : TimeSpan, _ : MaxValue) =
+    static member MaxValue (_: TimeSpan, _: MaxValue) : TimeSpan =
         TimeSpan.MaxValue
 #endif
 
     static member inline Invoke () =
-        let inline call_2 (a : ^a, b : ^b) =
-            ((^a or ^b) : (static member MaxValue: _ * _ -> _) b, a)
-        let inline call (a : 'a) =
-            call_2 (a, Unchecked.defaultof<'r>) :'r
-        call Unchecked.defaultof<MaxValue>
+        let inline call2 (a: ^a, b: ^b) =
+            ((^a or ^b): (static member MaxValue: _ * _ -> _) b, a)
+        let inline call1 (a: 'a) =
+            call2 (a, Unchecked.defaultof<'r>) : 'r
+        call1 Unchecked.defaultof<MaxValue>
 
     static member inline MaxValue ((_ : 'a * 'b), _ : MaxValue) =
         (MaxValue.Invoke(), MaxValue.Invoke())
@@ -172,110 +172,111 @@ type MaxValue =
         (MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke(), MaxValue.Invoke())
 
 type FromBigInt =
-    static member FromBigInt (_ : int32, _ : FromBigInt) =
-        fun (x : bigint) -> int x
 
-    static member FromBigInt (_ : int64, _ : FromBigInt) =
-        fun (x : bigint) -> int64 x
+    static member FromBigInt (_: bigint, _: FromBigInt) : bigint -> bigint =
+        id
+
+    static member FromBigInt (_: uint8, _: FromBigInt) : bigint -> uint8 =
+        uint8 << int32
+
+    static member FromBigInt (_: uint16, _: FromBigInt) : bigint -> uint16 =
+        uint16 << int32
+
+    static member FromBigInt (_: uint32, _: FromBigInt) : bigint -> uint32 =
+        uint32
+
+    static member FromBigInt (_: uint64, _: FromBigInt) : bigint -> uint64 =
+        uint64
+
+    static member FromBigInt (_: int8, _: FromBigInt) : bigint -> int8 =
+        int8 << int32
+
+    static member FromBigInt (_: int16, _: FromBigInt) : bigint -> int16 =
+        int16 << int32
+
+    static member FromBigInt (_: int32, _: FromBigInt) : bigint -> int32 =
+        int32
+
+    static member FromBigInt (_: int64, _: FromBigInt) : bigint -> int64 =
+        int64
+
+    static member FromBigInt (_: single, _: FromBigInt) : bigint -> single =
+        single
+
+    static member FromBigInt (_: double, _: FromBigInt) : bigint -> double =
+        double
+
+    static member FromBigInt (_: decimal, _: FromBigInt) : bigint -> decimal =
+        decimal << int32
 
 #if !FABLE_COMPILER
-    static member FromBigInt (_ : nativeint , _ : FromBigInt) =
-        fun (x : bigint) -> nativeint (int x)
+    static member FromBigInt (_: nativeint , _: FromBigInt) : bigint -> nativeint =
+        nativeint << int32
 
-    static member FromBigInt (_ : unativeint, _ : FromBigInt) =
-        fun (x : bigint) -> unativeint (int x)
+    static member FromBigInt (_: unativeint, _: FromBigInt) : bigint -> unativeint =
+        unativeint << int32
 #endif
 
-    static member FromBigInt (_ : bigint, _ : FromBigInt) =
-        fun (x : bigint) -> x
-
-    static member FromBigInt (_ : float, _ : FromBigInt) =
-        fun (x : bigint) -> float x
-
-    static member FromBigInt (_ : sbyte, _ : FromBigInt) =
-        fun (x : bigint) -> sbyte (int x)
-
-    static member FromBigInt (_ : int16, _ : FromBigInt) =
-        fun (x : bigint) -> int16 (int x)
-
-    static member FromBigInt (_ : byte, _ : FromBigInt) =
-        fun (x : bigint) -> byte (int x)
-
-    static member FromBigInt (_ : uint16, _ : FromBigInt) =
-        fun (x : bigint) -> uint16 (int x)
-
-    static member FromBigInt (_ : uint32, _ : FromBigInt) =
-        fun (x : bigint) -> uint32 x
-
-    static member FromBigInt (_ : uint64, _ : FromBigInt) =
-        fun (x : bigint) -> uint64 x
-
-    static member FromBigInt (_ : float32, _ : FromBigInt) =
-        fun (x : bigint) -> float32 (int x)
-
-    static member FromBigInt (_ : decimal, _ : FromBigInt) =
-        fun (x : bigint) -> decimal (int x)
-
-    static member inline Invoke (x : bigint) : 'Num =
-        let inline call_2 (a : ^a, b : ^b) =
-            ((^a or ^b) : (static member FromBigInt : _ * _ -> _) b, a)
-        let inline call (a : 'a) =
-            fun (x : 'x) -> call_2 (a, Unchecked.defaultof<'r>) x :'r
-        call Unchecked.defaultof<FromBigInt> x
+    static member inline Invoke (x: bigint) : 'Num =
+        let inline call2 (a: ^a, b: ^b) =
+            ((^a or ^b): (static member FromBigInt: _ * _ -> _) b, a)
+        let inline call1 (a: 'a) =
+            fun (x: 'x) -> call2 (a, Unchecked.defaultof<'r>) x : 'r
+        call1 Unchecked.defaultof<FromBigInt> x
 
 type ToBigInt =
-    static member ToBigInt (x : sbyte) =
-        bigint (int x)
 
-    static member ToBigInt (x : int16) =
-        bigint (int x)
-
-    static member ToBigInt (x : int32) =
-        bigint x
-
-    static member ToBigInt (x : int64) =
-        bigint x
-
-#if !FABLE_COMPILER
-    static member ToBigInt (x : nativeint) =
-        bigint (int x)
-#endif
-
-    static member ToBigInt (x : byte) =
-        bigint (int x)
-
-    static member ToBigInt (x : uint16) =
-        bigint (int x)
-
-#if !FABLE_COMPILER
-    static member ToBigInt (x : unativeint) =
-        bigint (int x)
-#endif
-
-    static member ToBigInt (x : bigint) =
+    static member ToBigInt (x: bigint) : bigint =
         x
 
-    static member ToBigInt (x : uint32) =
+    static member ToBigInt (x: uint8) : bigint =
+        bigint (int x)
+
+    static member ToBigInt (x: uint16) : bigint =
+        bigint (int x)
+
+    static member ToBigInt (x: uint32) : bigint =
         bigint x
 
-    static member ToBigInt (x : uint64) =
+    static member ToBigInt (x: uint64) : bigint =
         bigint x
 
-    static member ToBigInt (x : single) =
-        bigint x
-        
-    static member ToBigInt (x : double) =
+    static member ToBigInt (x: int8) : bigint =
+        bigint (int x)
+
+    static member ToBigInt (x: int16) : bigint =
+        bigint (int x)
+
+    static member ToBigInt (x: int32) : bigint =
         bigint x
 
-    static member ToBigInt (x : decimal) =
+    static member ToBigInt (x: int64) : bigint =
         bigint x
-    
-    static member inline Invoke (x :'Integral) : bigint =
-        let inline call_2 (a : ^a, b : ^b) =
-            ((^a or ^b) : (static member ToBigInt : _ -> _) b)
-        call_2 (Unchecked.defaultof<ToBigInt>, x)
+
+    static member ToBigInt (x: single) : bigint =
+        bigint x
+
+    static member ToBigInt (x: double) : bigint =
+        bigint x
+
+    static member ToBigInt (x: decimal) : bigint =
+        bigint x
+
+#if !FABLE_COMPILER
+    static member ToBigInt (x : nativeint) : bigint =
+        bigint (int32 x)
+
+    static member ToBigInt (x : unativeint) : bigint =
+        bigint (int32 x)
+#endif
+
+    static member inline Invoke (x: 'Integral) : bigint =
+        let inline call (a: ^a, b: ^b) : ^r =
+            ((^a or ^b): (static member ToBigInt: _ -> _) b)
+        call (Unchecked.defaultof<ToBigInt>, x)
 
 module Numeric =
+
     /// Returns the smallest possible value.
     let inline minValue () : ^a =
         MinValue.Invoke ()
@@ -285,9 +286,9 @@ module Numeric =
         MaxValue.Invoke ()
 
     /// Converts from a BigInt to the inferred destination type.
-    let inline fromBigInt (x : bigint) : ^a =
+    let inline fromBigInt (x: bigint) : ^a =
         FromBigInt.Invoke x
 
     /// Converts to a BigInt.
-    let inline toBigInt (x : ^a) : bigint =
+    let inline toBigInt (x: ^a) : bigint =
         ToBigInt.Invoke x


### PR DESCRIPTION
This is the first in a series of PRs I am planning to put up, to enforce a consistent style across the project. I believe these changes follow the style guide (more or less), I also took this opportunity to re-order the functions in a consistent order. The order is

- `unit`
- `bool`
- `char`
- `unsigned` types
- `signed` types
- `float` types
- `decimal`

The integer types all use the `u?int\d+` aliases (`uint8`, `int8`, etc).

Functions were also grouped to reduce the instances of `#if !FABLE_COMPILER` directives.

`ToBigInt`/`FromBigInt` functions use composition now, to eliminate lint warnings.

If the style in this PR is approved, I can move forward and do similar changes in the other files.

/cc @moodmosaic @TysonMN