### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/Hedgehog.Linq.Tests/LinqTests.cs
+++ b/tests/Hedgehog.Linq.Tests/LinqTests.cs
@@ -81,9 +81,9 @@ namespace Hedgehog.Linq.Tests
         public void CanUseWhereWithAssertion()
         {
             var property =
-                from x in ForAll(Gen.Bool)
+                from x in ForAll(Gen.FromValue(true))
                 where x == true
-                from y in ForAll(Gen.Bool)
+                from y in ForAll(Gen.FromValue(false))
                 where y == false
                 select Assert.True(x && !y);
 
@@ -94,9 +94,9 @@ namespace Hedgehog.Linq.Tests
         public void CanUseWhereWithBool()
         {
             var property =
-                from x in ForAll(Gen.Bool)
+                from x in ForAll(Gen.FromValue(true))
                 where x == true
-                from y in ForAll(Gen.Bool)
+                from y in ForAll(Gen.FromValue(false))
                 where y == false
                 select x && !y;
 


### PR DESCRIPTION
fixes #283

This addresses an issue we've had in CI, where the tests for `PropertyExtensions.Where` hit a discard limit and fail. If we generate the data such that the predicate in `PropertyExtensions.Where` always evaluates to true, we will no longer hit the discard limit randomly.

/cc @moodmosaic @TysonMN