### PR TITLE
Remove PropertyConfig.coalesce

### DIFF
--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -4,9 +4,7 @@ namespace Hedgehog.Linq
 
 open System
 open System.Runtime.CompilerServices
-open System.Runtime.InteropServices
 open Hedgehog
-
 
 type Property = private Property of Property<unit> with
 
@@ -68,77 +66,77 @@ type PropertyExtensions private () =
     static member TryWith (property : Property<'T>, onError : Func<exn, Property<'T>>) : Property<'T> =
         Property.tryWith onError.Invoke property
 
-    //
-    // Runner
-    //
-
     [<Extension>]
-    static member Report
-        (   property : Property,
-            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
-        ) : Report =
+    static member Report (property : Property) : Report =
         let (Property property) = property
-        Property.reportWith (PropertyConfig.coalesce config) property
+        Property.report property
 
     [<Extension>]
-    static member Report
-        (   property : Property<bool>,
-            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
-        ) : Report =
-        Property.reportBoolWith (PropertyConfig.coalesce config) property
-
-    [<Extension>]
-    static member Check
-        (   property : Property,
-            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
-        ) : unit =
+    static member Report (property : Property, config : Hedgehog.PropertyConfig) : Report =
         let (Property property) = property
-        Property.checkWith (PropertyConfig.coalesce config) property
+        Property.reportWith config property
 
     [<Extension>]
-    static member Check
-        (   property : Property<bool>,
-            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
-        ) : unit =
-        Property.checkBoolWith (PropertyConfig.coalesce config) property
+    static member Report (property : Property<bool>) : Report =
+        Property.reportBool property
 
     [<Extension>]
-    static member Recheck
-        (   property : Property,
-            size : Size,
-            seed : Seed,
-            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
-        ) : unit =
+    static member Report (property : Property<bool>, config : Hedgehog.PropertyConfig) : Report =
+        Property.reportBoolWith config property
+
+    [<Extension>]
+    static member Check (property : Property) : unit =
         let (Property property) = property
-        Property.recheckWith size seed (PropertyConfig.coalesce config) property
+        Property.check property
 
     [<Extension>]
-    static member Recheck
-        (   property : Property<bool>,
-            size : Size,
-            seed : Seed,
-            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
-        ) : unit =
-        Property.recheckBoolWith size seed (PropertyConfig.coalesce config) property
-
-    [<Extension>]
-    static member ReportRecheck
-        (   property : Property,
-            size : Size,
-            seed : Seed,
-            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
-        ) : Report =
+    static member Check (property : Property, config : Hedgehog.PropertyConfig) : unit =
         let (Property property) = property
-        Property.reportRecheckWith size seed (PropertyConfig.coalesce config) property
+        Property.checkWith config property
 
     [<Extension>]
-    static member ReportRecheck
-        (   property : Property<bool>,
-            size : Size,
-            seed : Seed,
-            [<Optional; DefaultParameterValue null>] ?config : Hedgehog.PropertyConfig
-        ) : Report =
-        Property.reportRecheckBoolWith size seed (PropertyConfig.coalesce config) property
+    static member Check (property : Property<bool>) : unit =
+        Property.checkBool property
+
+    [<Extension>]
+    static member Check (property : Property<bool>, config : Hedgehog.PropertyConfig) : unit =
+        Property.checkBoolWith config property
+
+    [<Extension>]
+    static member Recheck (property : Property, size : Size, seed : Seed) : unit =
+        let (Property property) = property
+        Property.recheck size seed property
+
+    [<Extension>]
+    static member Recheck (property : Property, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : unit =
+        let (Property property) = property
+        Property.recheckWith size seed config property
+
+    [<Extension>]
+    static member Recheck (property : Property<bool>, size : Size, seed : Seed) : unit =
+        Property.recheckBool size seed property
+
+    [<Extension>]
+    static member Recheck (property : Property<bool>, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : unit =
+        Property.recheckBoolWith size seed config property
+
+    [<Extension>]
+    static member ReportRecheck (property : Property, size : Size, seed : Seed) : Report =
+        let (Property property) = property
+        Property.reportRecheck size seed property
+
+    [<Extension>]
+    static member ReportRecheck (property : Property, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : Report =
+        let (Property property) = property
+        Property.reportRecheckWith size seed config property
+
+    [<Extension>]
+    static member ReportRecheck (property : Property<bool>, size : Size, seed : Seed) : Report =
+        Property.reportRecheckBool size seed property
+
+    [<Extension>]
+    static member ReportRecheck (property : Property<bool>, size : Size, seed : Seed, config : Hedgehog.PropertyConfig) : Report =
+        Property.reportRecheckBoolWith size seed config property
 
     [<Extension>]
     static member Where (property : Property<'T>, filter : Func<'T, bool>) : Property<'T> =

--- a/src/Hedgehog/Linq/PropertyConfig.fs
+++ b/src/Hedgehog/Linq/PropertyConfig.fs
@@ -32,10 +32,4 @@ type PropertyConfig =
     static member Default : Hedgehog.PropertyConfig =
         PropertyConfig.defaultConfig
 
-
-module internal PropertyConfig =
-    let coalesce = function
-        | Some x -> x
-        | None -> PropertyConfig.defaultConfig
-
 #endif


### PR DESCRIPTION
Instead of making an overload that accepts a null `PropertyConfig` then converting that to a valid one, this PR creates separate overloads so this can be handled statically with overload resolution.

/cc @moodmosaic @TysonMN