### PR TITLE
Implement Property.select via bind to avoid bug

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ trim_trailing_whitespace = true
 
 [*.csproj, *.fsproj, *.props]
 indent_size = 2
+
+[*.cs]
+csharp_new_line_before_open_brace = all

--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -48,6 +48,7 @@ https://github.com/hedgehogqa/fsharp-hedgehog/blob/master/doc/index.md
     <Compile Include="Linq\PropertyConfig.fs" />
     <Compile Include="Linq\Property.fs" />
     <Compile Include="Linq\Range.fs" />
+    <Compile Include="Linq\Report.fs" />
     <None Include="Script.fsx" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -162,7 +162,8 @@ type PropertyExtensions private () =
 
     [<Extension>]
     static member Select (property : Property<'T>, mapper : Func<'T, 'TResult>) : Property<'TResult> =
-        Property.map mapper.Invoke property
+        property
+        |> Property.bind (Property.ofThrowing mapper.Invoke)
 
     [<Extension>]
     static member Select (property : Property<'T>, mapper : Action<'T>) : Property =

--- a/src/Hedgehog/Linq/Report.fs
+++ b/src/Hedgehog/Linq/Report.fs
@@ -1,0 +1,16 @@
+﻿namespace Hedgehog.Linq
+
+#if !FABLE_COMPILER
+
+open System.Runtime.CompilerServices
+open Hedgehog
+
+[<Extension>]
+[<AbstractClass; Sealed>]
+type ReportExtensions private () =
+
+    [<Extension>]
+    static member Render (report: Report) : string =
+        Report.render report
+
+#endif

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -98,9 +98,10 @@ module Property =
 
         value |> prepareForPrinting |> sprintf "%A"
 
+    let handle (e : exn) =
+        Gen.constant (Journal.singletonMessage (string e), Failure) |> ofGen
+
     let forAll (k : 'a -> Property<'b>) (gen : Gen<'a>) : Property<'b> =
-        let handle (e : exn) =
-            Gen.constant (Journal.singletonMessage (string e), Failure) |> ofGen
         let prepend (x : 'a) =
             counterexample (fun () -> printValue x)
             |> bind (fun _ -> try k x with e -> handle e)
@@ -216,8 +217,8 @@ module Property =
     let ofThrowing (f : 'a -> 'b) (a : 'a) : Property<'b> =
         try
             success (f a)
-        with
-        | _ -> Failure |> ofOutcome
+        with e ->
+            handle e
 
     let reportRecheckWith (size : Size) (seed : Seed) (config : PropertyConfig) (p : Property<unit>) : Report =
         let args = {

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -98,7 +98,7 @@ module Property =
 
         value |> prepareForPrinting |> sprintf "%A"
 
-    let handle (e : exn) =
+    let private handle (e : exn) =
         Gen.constant (Journal.singletonMessage (string e), Failure) |> ofGen
 
     let forAll (k : 'a -> Property<'b>) (gen : Gen<'a>) : Property<'b> =

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -212,7 +212,7 @@ module Property =
         g |> bind ofBool |> checkWith config
 
     /// Converts a possibly-throwing function to
-    /// a property by treating an exception a failure.
+    /// a property by treating an exception as a failure.
     let ofThrowing (f : 'a -> 'b) (a : 'a) : Property<'b> =
         try
             success (f a)

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -212,13 +212,12 @@ module Property =
         g |> bind ofBool |> checkWith config
 
     /// Converts a possibly-throwing function to
-    /// a property by treating "no exception" as success.
-    let ofThrowing (f : 'a -> unit) (x : 'a) : Property<unit> =
+    /// a property by treating an exception a failure.
+    let ofThrowing (f : 'a -> 'b) (a : 'a) : Property<'b> =
         try
-            f x
-            success ()
+            success (f a)
         with
-        | _ -> failure
+        | _ -> Failure |> ofOutcome
 
     let reportRecheckWith (size : Size) (seed : Seed) (config : PropertyConfig) (p : Property<unit>) : Report =
         let args = {

--- a/tests/Hedgehog.Linq.Tests/LinqTests.cs
+++ b/tests/Hedgehog.Linq.Tests/LinqTests.cs
@@ -12,7 +12,7 @@ namespace Hedgehog.Linq.Tests
         [Fact]
         public void ExceptionInSelect_Action_FailedStatus()
         {
-            void action() => throw new Exception();
+            static void action() => throw new Exception();
             var property =
                 from _ in Property.ForAll(Gen.Int32(Range.Constant(0, 0)))
                 select action();
@@ -23,7 +23,7 @@ namespace Hedgehog.Linq.Tests
         [Fact]
         public void ExceptionInSelect_Func_FailedStatus()
         {
-            bool func() => throw new Exception();
+            static bool func() => throw new Exception();
             var property =
                 from x in Property.ForAll(Gen.Int32(Range.Constant(0, 0)))
                 select func();

--- a/tests/Hedgehog.Linq.Tests/LinqTests.cs
+++ b/tests/Hedgehog.Linq.Tests/LinqTests.cs
@@ -6,10 +6,12 @@ using static Hedgehog.Linq.Property;
 
 namespace Hedgehog.Linq.Tests
 {
-    public class LinqTests {
+    public class LinqTests
+    {
 
         [Fact]
-        public void ExceptionInSelect_Action_FailedStatus() {
+        public void ExceptionInSelect_Action_FailedStatus()
+        {
             void action() => throw new Exception();
             var property =
                 from _ in Property.ForAll(Gen.Int32(Range.Constant(0, 0)))
@@ -19,7 +21,8 @@ namespace Hedgehog.Linq.Tests
         }
 
         [Fact]
-        public void ExceptionInSelect_Func_FailedStatus() {
+        public void ExceptionInSelect_Func_FailedStatus()
+        {
             bool func() => throw new Exception();
             var property =
                 from x in Property.ForAll(Gen.Int32(Range.Constant(0, 0)))

--- a/tests/Hedgehog.Linq.Tests/LinqTests.cs
+++ b/tests/Hedgehog.Linq.Tests/LinqTests.cs
@@ -12,23 +12,29 @@ namespace Hedgehog.Linq.Tests
         [Fact]
         public void ExceptionInSelect_Action_FailedStatus()
         {
-            static void action() => throw new Exception();
+            var guid = Guid.NewGuid().ToString();
+            void action() => throw new Exception(guid);
             var property =
                 from _ in Property.ForAll(Gen.Int32(Range.Constant(0, 0)))
                 select action();
             var report = property.Report();
+            var rendered = report.Render();
             Assert.True(report.Status.IsFailed);
+            Assert.Contains(guid, rendered);
         }
 
         [Fact]
         public void ExceptionInSelect_Func_FailedStatus()
         {
-            static bool func() => throw new Exception();
+            var guid = Guid.NewGuid().ToString();
+            bool func() => throw new Exception(guid);
             var property =
                 from x in Property.ForAll(Gen.Int32(Range.Constant(0, 0)))
                 select func();
             var report = property.Report();
+            var rendered = report.Render();
             Assert.True(report.Status.IsFailed);
+            Assert.Contains(guid, rendered);
         }
 
         /*

--- a/tests/Hedgehog.Linq.Tests/LinqTests.cs
+++ b/tests/Hedgehog.Linq.Tests/LinqTests.cs
@@ -1,16 +1,38 @@
-﻿using Xunit;
+﻿using System;
+using Xunit;
 
 // Import ForAll:
 using static Hedgehog.Linq.Property;
 
 namespace Hedgehog.Linq.Tests
 {
-    /*
-     * The main object here is just to make sure that the examples compile,
-     * there's nothing fancy in the properties being tested.
-     */
-    public class LinqTests
-    {
+    public class LinqTests {
+
+        [Fact]
+        public void ExceptionInSelect_Action_FailedStatus() {
+            void action() => throw new Exception();
+            var property =
+                from _ in Property.ForAll(Gen.Int32(Range.Constant(0, 0)))
+                select action();
+            var report = property.Report();
+            Assert.True(report.Status.IsFailed);
+        }
+
+        [Fact]
+        public void ExceptionInSelect_Func_FailedStatus() {
+            bool func() => throw new Exception();
+            var property =
+                from x in Property.ForAll(Gen.Int32(Range.Constant(0, 0)))
+                select func();
+            var report = property.Report();
+            Assert.True(report.Status.IsFailed);
+        }
+
+        /*
+         * The main object the following tests is just to make sure that the examples compile.
+         * There's nothing fancy in the properties being tested.
+         */
+
         [Fact]
         public void CanUseSelectWithAssertion()
         {


### PR DESCRIPTION
Fixes #317

I added tests corresponding to those given in #317 except that they pass when the behavior is correct and fail otherwise.  Then I fixed the issue by implementing `Property.select` via `Property.bind` and especially `Property.ofThrowing`, which maps a thrown exception to `Outcome<_>.Failure`.