### PR TITLE
Remove duplicates in frequency shrink tree

### DIFF
--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -206,8 +206,26 @@ module Gen =
                 else
                     pick (n - k) ys
 
+        let f n =
+            let smallWeights =
+                xs
+                |> List.map fst
+                |> List.scan (+) 0
+                |> List.pairwise
+                |> List.takeWhile (fun (a, _) -> a < n)
+                |> List.map snd
+                |> List.toArray
+            let length = smallWeights |> Array.length
+            Shrink.createTree 0 (length - 1)
+            |> Tree.map (fun i -> smallWeights.[i])
+
         gen {
-            let! n = Range.constant 1 total |> integral
+            let! n =
+                Range.constant 1 total
+                |> integral
+                |> toRandom
+                |> Random.map (Tree.outcome >> f)
+                |> ofRandom
             return! pick n xs
         }
 

--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -190,7 +190,7 @@ module Gen =
     /// Uses a weighted distribution to randomly select one of the gens in the list.
     /// This generator shrinks towards the first generator in the list.
     /// <i>The input list must be non-empty.</i>
-    let frequency (xs0 : seq<int * Gen<'a>>) : Gen<'a> = gen {
+    let frequency (xs0 : seq<int * Gen<'a>>) : Gen<'a> =
         let xs =
             List.ofSeq xs0
 
@@ -206,9 +206,10 @@ module Gen =
                 else
                     pick (n - k) ys
 
-        let! n = Range.constant 1 total |> integral
-        return! pick n xs
-    }
+        gen {
+            let! n = Range.constant 1 total |> integral
+            return! pick n xs
+        }
 
     /// Randomly selects one of the gens in the list.
     /// <i>The input list must be non-empty.</i>

--- a/src/Hedgehog/Tree.fs
+++ b/src/Hedgehog/Tree.fs
@@ -31,12 +31,18 @@ module Tree =
     let rec cata (f: 'a -> 'b seq -> 'b) (Node (x, xs): Tree<'a>) : 'b =
         f x (Seq.map (cata f) xs)
 
+    let depth (tree: Tree<'a>) : int =
+        tree |> cata (fun _ -> Seq.fold max -1 >> (+) 1)
+
     let toSeq (tree: Tree<'a>) : 'a seq =
         tree |> cata (fun a -> Seq.join >> Seq.cons a)
 
     /// Map over a tree.
     let rec map (f : 'a -> 'b) (Node (x, xs) : Tree<'a>) : Tree<'b> =
         Node (f x, Seq.map (map f) xs)
+
+    let mapWithSubtrees (f: 'a -> seq<Tree<'b>> -> 'b) (tree: Tree<'a>) : Tree<'b> =
+        tree |> cata (fun a subtrees -> Node (f a subtrees, subtrees))
 
     let rec bind (k : 'a -> Tree<'b>) (Node (x, xs0) : Tree<'a>) : Tree<'b> =
         match k x with

--- a/tests/Hedgehog.Tests/GenTests.fs
+++ b/tests/Hedgehog.Tests/GenTests.fs
@@ -96,4 +96,14 @@ let genTests = testList "Gen tests" [
     testCase "apply operator works as expected" <| fun _ ->
         let _ : Gen<int> = (+) <!> (Gen.constant 1) <*> (Gen.constant 1)
         ()
+
+    testCase "frequency shrink tree is free of duplicates" <| fun _ ->
+        let actual =
+            [(100, Gen.constant "a")]
+            |> Gen.frequency
+            |> Gen.toRandom
+            |> Random.run (Seed.from 0UL) 0
+            |> Tree.toSeq
+            |> Seq.length
+        1 =! actual
 ]

--- a/tests/Hedgehog.Tests/TreeTests.fs
+++ b/tests/Hedgehog.Tests/TreeTests.fs
@@ -4,6 +4,19 @@ open Hedgehog
 open TestDsl
 
 let treeTests = testList "Tree tests" [
+    testCase "depth of tree with no subtrees is 0" <| fun _ ->
+        let actual =
+            Tree.singleton "a"
+            |> Tree.depth
+        0 =! actual
+
+    testCase "depth of tree with only one subtree of depth 0 is 1" <| fun _ ->
+        let actual =
+            Tree.singleton "a"
+            |> Tree.addChildValue "b"
+            |> Tree.depth
+        1 =! actual
+
     testCase "render tree with depth 0" <| fun _ ->
         Property.check (property {
             let! x0 = Gen.constant "0"


### PR DESCRIPTION
Fixes #319

We had the same bug that Haskell had.  They fixed this bug in PR https://github.com/hedgehogqa/haskell-hedgehog/pull/406.  I tried to mimic their solution here.  I think I was successful.

CC @HuwCampbell

I did one thing differently related to their `shrink` function.  I think the input `n` of the lambda to `shrink` is put into the root of the shrink tree by `shrink`.  Instead, I avoided an off-by-one error by first paring the weights and then calling `takeWhile`.  Without pairing, the resulting sequence does not include the weight corresponding to the weight `k` in the base case of `pick`.