### PR TITLE
Fix for counterexample crashing bug #327

### DIFF
--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -78,8 +78,11 @@ module Property =
             | Success x ->
                 GenTuple.mapFst (Journal.append journal) (k x))
 
+    let private handle (e : exn) =
+        Gen.constant (Journal.singletonMessage (string e), Failure) |> ofGen
+
     let bind (k : 'a -> Property<'b>) (m : Property<'a>) : Property<'b> =
-        bindGen (toGen << k) (toGen m) |> ofGen
+        bindGen (fun a -> (try k a with e -> handle e) |> toGen) (toGen m) |> ofGen
 
     let private printValue (value) : string =
         // sprintf "%A" is not prepared for printing ResizeArray<_> (C# List<T>) so we prepare the value instead

--- a/tests/Hedgehog.Tests/PropertyTests.fs
+++ b/tests/Hedgehog.Tests/PropertyTests.fs
@@ -14,4 +14,19 @@ let propertyTests = testList "Property tests" [
             |> Property.renderWith (PropertyConfig.withShrinks 0<shrinks> PropertyConfig.defaultConfig)
         Expect.isNotMatch report "\.\.\." "Abbreviation (...) found"
 
+    testCase "counterexample example" <| fun () ->
+        // based on examlpe from https://hedgehogqa.github.io/fsharp-hedgehog/index.html#Custom-Operations
+        let guid = System.Guid.NewGuid().ToString()
+        let tryAdd a b =
+            if a > 100 then None // Nasty bug.
+            else Some(a + b)
+        let report =
+            property {
+                let! a = Range.constantBounded () |> Gen.int
+                let! b = Range.constantBounded () |> Gen.int
+                counterexample guid
+                Some(a + b) =! tryAdd a b
+            }
+            |> Property.renderWith (PropertyConfig.withShrinks 0<shrinks> PropertyConfig.defaultConfig)
+        Expect.stringContains report guid "Missing counterexample text"
 ]

--- a/tests/Hedgehog.Tests/PropertyTests.fs
+++ b/tests/Hedgehog.Tests/PropertyTests.fs
@@ -28,5 +28,10 @@ let propertyTests = testList "Property tests" [
                 Some(a + b) =! tryAdd a b
             }
             |> Property.renderWith (PropertyConfig.withShrinks 0<shrinks> PropertyConfig.defaultConfig)
+#if FABLE_COMPILER
+// See the discussion in this PR for what needs to happen for Fable to support Expect.stringContains https://github.com/hedgehogqa/fsharp-hedgehog/pull/328
+        Expect.isTrue (report.Contains guid)
+#else
         Expect.stringContains report guid "Missing counterexample text"
+#endif
 ]


### PR DESCRIPTION
Fixes #327

I think this PR fixes the bug where an exception isn't caught when checking a `Property<_>` containing `counterexample`.  I got the idea for this fix by looking at `Property.forall`, which is the only other place that `Property.counterexample` is called.  In the last commit, I removed the exception handling code from `Property.forall` since it is now happening in `Property.bind`.

How does this compare to the code in Haskell Hedgehog?

@AlexeyRaga, does the branch in this PR give the behavior that you expect?