### PR TITLE
Remove extra sized call

### DIFF
--- a/src/Hedgehog/Gen.fs
+++ b/src/Hedgehog/Gen.fs
@@ -401,7 +401,7 @@ module Gen =
     /// Generates a random string using 'Range' to determine the length and the
     /// specified character generator.
     let string (range : Range<int>) (g : Gen<char>) : Gen<string> =
-        sized (fun _size -> array range g)
+        array range g
         |> map String
 
     //


### PR DESCRIPTION
Just a quick PR to remove an extra call to `Gen.sized`. The function passed to it is essentially `always (array range g)`, eliminating the only reason to used `Gen.sized`.

/cc @moodmosaic @TysonMN 