### PR TITLE
allow tests to access internal scope

### DIFF
--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -25,6 +25,9 @@ https://github.com/hedgehogqa/fsharp-hedgehog/blob/master/doc/index.md
     <RepositoryUrl>https://github.com/hedgehogqa/fsharp-hedgehog</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Hedgehog.Tests</_Parameter1>
+    </AssemblyAttribute>
     <Compile Include="AutoOpen.fs" />
     <Compile Include="Numeric.fs" />
     <Compile Include="Seed.fs" />


### PR DESCRIPTION
This is a change that I am splitting off of draft PR #336.  I think it is ready to merge now.

This PR allows the `Hedgehog.Tests` project to access types and functions in the `Hedgehog` project that have internal scope.  This is helpful because we can be more conservative about adding to the public API while still adding tests for this code.