### PR TITLE
change access scope for two top-level modules from private to internal

### DIFF
--- a/src/Hedgehog/GenTuple.fs
+++ b/src/Hedgehog/GenTuple.fs
@@ -2,7 +2,7 @@
 #if FABLE_COMPILER
 module Hedgehog.GenTuple
 #else
-module private Hedgehog.GenTuple
+module internal Hedgehog.GenTuple
 #endif
 
 let mapFst (f : 'a -> 'c) (gen : Gen<'a * 'b>) : Gen<'c * 'b> =

--- a/src/Hedgehog/Tuple.fs
+++ b/src/Hedgehog/Tuple.fs
@@ -2,7 +2,7 @@
 #if FABLE_COMPILER
 module Hedgehog.Tuple
 #else
-module private Hedgehog.Tuple
+module internal Hedgehog.Tuple
 #endif
 
 let mapFst (f : 'a -> 'c) (x : 'a, y : 'b) : 'c * 'b =


### PR DESCRIPTION
This is a change that I am splitting off of draft PR #336. I think it is ready to merge now.

This PR changes the access scope of two top-level modules from private to internal.  I didn't know that top-level modules could be private.  It seems to me that private and internal mean the same thing for top-level modules.  However, Visual Studio displayed the functions as transparent as though they were unused and returned no search results for references.  Strangely though, it was possible to navigate from a reference to one of these definitions.  None of these problems exist after changing the scope to internal.