### PR TITLE
Add error handling to Property.map

### DIFF
--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -64,8 +64,13 @@ module Property =
         p |> toGen |> f |> ofGen
 
     let map (f : 'a -> 'b) (x : Property<'a>) : Property<'b> =
-        let g = f |> Outcome.map |> GenTuple.mapSnd |> mapGen
-        g x
+        let g (j, outcome) =
+            try
+                (j, outcome |> Outcome.map f)
+            with e ->
+                (Journal.append j (Journal.singletonMessage (string e)), Failure)
+        let h = g |> Gen.map |> mapGen
+        h x
 
     let private set (a: 'a) (property : Property<'b>) : Property<'a> =
         property |> map (fun _ -> a)

--- a/tests/Hedgehog.Tests/PropertyTests.fs
+++ b/tests/Hedgehog.Tests/PropertyTests.fs
@@ -14,6 +14,23 @@ let propertyTests = testList "Property tests" [
             |> Property.renderWith (PropertyConfig.withShrinks 0<shrinks> PropertyConfig.defaultConfig)
         Expect.isNotMatch report "\.\.\." "Abbreviation (...) found"
 
+    testCase "exception thrown in map leads to Outcome.Failure" <| fun () ->
+        let prop =
+            property {
+                let! b = Gen.bool
+                return b
+            }
+            |> Property.map (fun _ -> failwith "exception in map")
+
+        let report = prop |> Property.report
+
+        let isFailure =
+            match report.Status with
+            | Failed _ -> true
+            | _ -> false
+        Expect.isTrue isFailure
+
+
     testCase "counterexample example" <| fun () ->
         // based on examlpe from https://hedgehogqa.github.io/fsharp-hedgehog/index.html#Custom-Operations
         let guid = System.Guid.NewGuid().ToString()


### PR DESCRIPTION
This PR is similar to PR #328, which fixed bug #327 by adding error handling to `Property.bind`.  Specifically, it adds essentially the same error handling to `Property.map`.  The first commit adds a failing test and the second commit makes that test pass.

This work is also adjacent to draft PR #336.  That draft currently has code similar (but weaker than due to its use of `Property.bind`) to error handling code in this PR.