### PR TITLE
Update benchmark project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ tests/Hedgehog.Fable.Tests/tests-js/
 # fable generated javascript files
 *.fs.js
 tests/Hedgehog.Tests/tests-js/
+
+# Benchmark generated files
+BenchmarkDotNet.Artifacts

--- a/tests/Hedgehog.Benchmarks/Hedgehog.Benchmarks.fsproj
+++ b/tests/Hedgehog.Benchmarks/Hedgehog.Benchmarks.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,8 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Hedgehog.Benchmarks/Program.fs
+++ b/tests/Hedgehog.Benchmarks/Program.fs
@@ -1,11 +1,10 @@
-﻿open System
-
-open BenchmarkDotNet.Attributes
+﻿open BenchmarkDotNet.Attributes
+open BenchmarkDotNet.Jobs
 open BenchmarkDotNet.Running
 
 open Hedgehog
 
-[<CoreJob>]
+[<SimpleJob(RuntimeMoniker.NetCoreApp31)>]
 type Benchmarks () =
 
     [<Benchmark>]
@@ -26,15 +25,14 @@ type Benchmarks () =
     member _.BigExampleFromTests () =
         Tests.MinimalTests.perfectMinimalShrink ()
 
-[<CoreJob>]
+[<SimpleJob(RuntimeMoniker.NetCoreApp31)>]
 type ScaledBenchmarks () =
 
-    [<Params (100, 1000)>] // 10000 is too big at the moment, overflows.
+    [<Params(100, 1000, 10000)>]
     member val N = 1 with get, set
 
     [<Benchmark>]
     member this.ForLoopTest () =
-
         Property.check (property {
             for _ = 0 to this.N do
                 ()
@@ -46,5 +44,4 @@ type ScaledBenchmarks () =
 let main argv =
     BenchmarkRunner.Run<Benchmarks> () |> ignore
     BenchmarkRunner.Run<ScaledBenchmarks> () |> ignore
-
     0 // return an integer exit code


### PR DESCRIPTION
Updated benchmark project to the latest `BenchmarkDotNet` version (`0.11.3` -> `0.13.1`). I also took the liberty to remove the explicit `FSharp.Core` reference, and I added another benchmark case for the `ForLoopTest`.

The `ForLoopTest` results show that we have some work to do there.. but that will be addressed in the future.

/cc @moodmosaic @TysonMN