### PR TITLE
simplify fix for #317

### DIFF
--- a/src/Hedgehog/Linq/Property.fs
+++ b/src/Hedgehog/Linq/Property.fs
@@ -163,12 +163,12 @@ type PropertyExtensions private () =
     [<Extension>]
     static member Select (property : Property<'T>, mapper : Func<'T, 'TResult>) : Property<'TResult> =
         property
-        |> Property.bind (Property.ofThrowing mapper.Invoke)
+        |> Property.map mapper.Invoke
 
     [<Extension>]
     static member Select (property : Property<'T>, mapper : Action<'T>) : Property =
         property
-        |> Property.bind (Property.ofThrowing mapper.Invoke)
+        |> Property.map mapper.Invoke
         |> Property
 
     [<Extension>]


### PR DESCRIPTION
This is (part of) the correct fix for #317.  I originally fixed that bug in PR #318 by implementing `Property.Select` via `Property.bind`.  However, I just (without realizing it until now) implemented the correct fix in PR #348.  Now this PR changes `Property.Select` to once again be implemented via `Property.map` as it should be.