### PR TITLE
Fix order of arguments to Expect.equal

### DIFF
--- a/tests/Hedgehog.Tests/TestDsl.fs
+++ b/tests/Hedgehog.Tests/TestDsl.fs
@@ -30,7 +30,7 @@ let fableIgnore (label : string) (test : unit -> unit) : TestCase =
 #endif
 
 let inline (=!) (actual : 'a) (expected : 'a) : unit =
-    Expect.equal expected actual "Should be equal"
+    Expect.equal actual expected "Should be equal"
 
 [<RequireQualifiedAccess>]
 module Expect =


### PR DESCRIPTION
Here is a screenshot of the tooltip for `Expect.equal` that shows the branch in this PR has the arguments in the correct order.

![2021-09-19_20-21-10_695_devenv](https://user-images.githubusercontent.com/34664007/133949646-5bcb8980-96fb-49e8-8609-711dd145d484.png)
