### PR TITLE
Fix a few things in our Seed implementation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,7 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1
 
 RUN apt update && apt -y install --no-install-recommends --no-install-suggests \
         bash-completion \
+        dieharder \
         less \
         nano \
  && apt -y autoremove \

--- a/Hedgehog.sln
+++ b/Hedgehog.sln
@@ -7,13 +7,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Hedgehog.Benchmarks", "tests/Hedgehog.Benchmarks/Hedgehog.Benchmarks.fsproj", "{7E2DE9D9-3831-46D7-B80F-B643E9D53FD3}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Hedgehog", "src\Hedgehog\Hedgehog.fsproj", "{0864FFED-D0B3-4D32-BD38-DB696B7FC5F3}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Hedgehog", "src/Hedgehog/Hedgehog.fsproj", "{0864FFED-D0B3-4D32-BD38-DB696B7FC5F3}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Hedgehog.Benchmarks", "tests\Hedgehog.Benchmarks\Hedgehog.Benchmarks.fsproj", "{7E2DE9D9-3831-46D7-B80F-B643E9D53FD3}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Hedgehog.Tests", "tests/Hedgehog.Tests/Hedgehog.Tests.fsproj", "{D38AB54A-D5E8-4B50-927C-472015473AFC}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Hedgehog.DieHarder", "tests\Hedgehog.DieHarder\Hedgehog.DieHarder.fsproj", "{48F11B6C-DB48-4244-8575-A4FE9F006E5F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hedgehog.Linq.Tests", "tests/Hedgehog.Linq.Tests/Hedgehog.Linq.Tests.csproj", "{952547C5-7622-45C8-BB3C-4D1BA2DB747D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hedgehog.Linq.Tests", "tests\Hedgehog.Linq.Tests\Hedgehog.Linq.Tests.csproj", "{952547C5-7622-45C8-BB3C-4D1BA2DB747D}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Hedgehog.Tests", "tests\Hedgehog.Tests\Hedgehog.Tests.fsproj", "{D38AB54A-D5E8-4B50-927C-472015473AFC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -25,18 +27,22 @@ Global
 		{0864FFED-D0B3-4D32-BD38-DB696B7FC5F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0864FFED-D0B3-4D32-BD38-DB696B7FC5F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0864FFED-D0B3-4D32-BD38-DB696B7FC5F3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D38AB54A-D5E8-4B50-927C-472015473AFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D38AB54A-D5E8-4B50-927C-472015473AFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D38AB54A-D5E8-4B50-927C-472015473AFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D38AB54A-D5E8-4B50-927C-472015473AFC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{952547C5-7622-45C8-BB3C-4D1BA2DB747D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{952547C5-7622-45C8-BB3C-4D1BA2DB747D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{952547C5-7622-45C8-BB3C-4D1BA2DB747D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{952547C5-7622-45C8-BB3C-4D1BA2DB747D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7E2DE9D9-3831-46D7-B80F-B643E9D53FD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7E2DE9D9-3831-46D7-B80F-B643E9D53FD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E2DE9D9-3831-46D7-B80F-B643E9D53FD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E2DE9D9-3831-46D7-B80F-B643E9D53FD3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48F11B6C-DB48-4244-8575-A4FE9F006E5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48F11B6C-DB48-4244-8575-A4FE9F006E5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48F11B6C-DB48-4244-8575-A4FE9F006E5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48F11B6C-DB48-4244-8575-A4FE9F006E5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{952547C5-7622-45C8-BB3C-4D1BA2DB747D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{952547C5-7622-45C8-BB3C-4D1BA2DB747D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{952547C5-7622-45C8-BB3C-4D1BA2DB747D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{952547C5-7622-45C8-BB3C-4D1BA2DB747D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D38AB54A-D5E8-4B50-927C-472015473AFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D38AB54A-D5E8-4B50-927C-472015473AFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D38AB54A-D5E8-4B50-927C-472015473AFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D38AB54A-D5E8-4B50-927C-472015473AFC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Hedgehog/Seed.fs
+++ b/src/Hedgehog/Seed.fs
@@ -142,7 +142,7 @@ module Seed =
                 if mag >= magtgt then
                     v0, seed0
                 else
-                    let x, seed1 = next seed0
+                    let x, seed1 = nextUInt64 seed0
                     let v1 = v0 * b + (bigint x - bigint genlo)
                     loop (mag * b) v1 seed1
 

--- a/src/Hedgehog/Seed.fs
+++ b/src/Hedgehog/Seed.fs
@@ -102,7 +102,7 @@ module Seed =
         Int64.MinValue, Int64.MaxValue
 
     /// Returns the next pseudo-random number in the sequence, and a new seed.
-    let private next (s : Seed) : uint64 * Seed =
+    let nextUInt64 (s : Seed) : uint64 * Seed =
         let s = { s with Value = s.Value + s.Gamma }
         let v = s.Value
         (v, s)
@@ -139,7 +139,7 @@ module Seed =
                 if mag >= magtgt then
                     v0, seed0
                 else
-                    let x, seed1 = next seed0
+                    let x, seed1 = nextUInt64 seed0
                     let v1 = v0 * b + (bigint x - bigint genlo)
                     loop (mag * b) v1 seed1
 
@@ -166,6 +166,6 @@ module Seed =
 
     /// Splits a 'Seed' in to two.
     let split (seed : Seed) : Seed * Seed =
-        let (value, seed1) = next seed
-        let (gamma, seed2) = next seed1
+        let (value, seed1) = nextUInt64 seed
+        let (gamma, seed2) = nextUInt64 seed1
         (seed2, mixSeed value gamma)

--- a/tests/Hedgehog.DieHarder/Hedgehog.DieHarder.fsproj
+++ b/tests/Hedgehog.DieHarder/Hedgehog.DieHarder.fsproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hedgehog\Hedgehog.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Hedgehog.DieHarder/Program.fs
+++ b/tests/Hedgehog.DieHarder/Program.fs
@@ -1,0 +1,10 @@
+﻿open Hedgehog
+
+[<EntryPoint>]
+let main _ =
+    let rec loop seed =
+        let (n, seed) = Seed.nextUInt64 seed
+        printfn "%d" n
+        loop seed
+    loop (Seed.random ())
+    0

--- a/tests/Hedgehog.DieHarder/Program.fs
+++ b/tests/Hedgehog.DieHarder/Program.fs
@@ -1,10 +1,16 @@
-﻿open Hedgehog
+open System
+open System.IO
+open Hedgehog
 
 [<EntryPoint>]
 let main _ =
+    use stdout = Console.OpenStandardOutput()
+    use writer = new BinaryWriter(stdout)
+
     let rec loop seed =
         let (n, seed) = Seed.nextUInt64 seed
-        printfn "%d" n
+        writer.Write(n)
         loop seed
+
     loop (Seed.random ())
     0

--- a/tests/Hedgehog.Tests/SeedTests.fs
+++ b/tests/Hedgehog.Tests/SeedTests.fs
@@ -27,4 +27,9 @@ let seedTests = testList "Seed tests" [
           { Value = value
             Gamma = gamma }
         expected =! Seed.from x
+
+    yield! testCases "Seed.bitCount is 1 for powers of 2"
+        [ 0 .. 63 ] <| fun shift ->
+        let value = 1UL <<< shift
+        1UL =! Seed.bitCount value
 ]


### PR DESCRIPTION
Following a discussion in #360, I've made this branch and PR.

This PR covers a few things I noticed in `Seed.fs`:

- Naming of `goldenGamma` changed to match the F# naming guidelines.
- Magic numbers for `range` replaced with preexisting int64 min/max constants.
- Verbiage of some comments were updated, and a small doc comment for `Gamma` was added.
- The `split` function has been corrected to match the `SplitMix` paper, as well as Haskell Hedgehog.
- The `nextSeed` function has been inlined to the one call site it was referenced in, after other clean ups were applied.

/cc @moodmosaic, @TysonMN