### PR TITLE
Add BindReturn to Property CE

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.403
+        dotnet-version: 5.0.403
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.403
+        dotnet-version: 5.0.403
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Version ?
 
 - Rename `Property.failOnFalse` to `Property.falseToFailure` ([#384][384], [@TysonMN][TysonMN])
+- Add `BindReturn` to the `property` CE ([#364][364], [@TysonMN][TysonMN])
+  - A breaking change.  Previously, returning a `bool` from a `property` CE (after using `let!`) caused the CE to have return type `Property<unit>`.  Now this results in a return type of `Property<bool>`.  The previous behavior can now be expressed by piping the `Property<bool>` instance into `Property.falseToFailure`.
 
 ## Version 0.11.1 (2021-11-19)
 
@@ -188,6 +190,8 @@
   https://github.com/hedgehogqa/fsharp-hedgehog/pull/381
 [380]:
   https://github.com/hedgehogqa/fsharp-hedgehog/pull/380
+[364]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/364
 [363]:
   https://github.com/hedgehogqa/fsharp-hedgehog/pull/363
 [362]:

--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -310,6 +310,12 @@ module PropertyBuilder =
         member __.Return(b : bool) : Property<unit> =
             Property.ofBool b
 
+        member __.BindReturn(m : Gen<'a>, f: 'a -> 'b) =
+            m
+            |> Gen.map (fun a -> (Journal.empty, Success a))
+            |> Property.ofGen
+            |> Property.map f
+
         member __.ReturnFrom(m : Property<'a>) : Property<'a> =
             m
 

--- a/tests/Hedgehog.Benchmarks/Hedgehog.Benchmarks.fsproj
+++ b/tests/Hedgehog.Benchmarks/Hedgehog.Benchmarks.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Hedgehog.Benchmarks/Program.fs
+++ b/tests/Hedgehog.Benchmarks/Program.fs
@@ -15,6 +15,7 @@ type Benchmarks () =
             let! i = Gen.int32 (Range.constant 0 10000)
             return i >= 0
         }
+        |> Property.falseToFailure
         |> Property.check
 
     [<Benchmark>]
@@ -23,6 +24,7 @@ type Benchmarks () =
             let! i = Gen.string (Range.constant 0 100) Gen.ascii
             return i.Length >= 0
         }
+        |> Property.falseToFailure
         |> Property.check
 
     [<Benchmark>]

--- a/tests/Hedgehog.Linq.Tests/Hedgehog.Linq.Tests.csproj
+++ b/tests/Hedgehog.Linq.Tests/Hedgehog.Linq.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <ApplicationIcon />
     <OutputType>Library</OutputType>

--- a/tests/Hedgehog.Tests/GenTests.fs
+++ b/tests/Hedgehog.Tests/GenTests.fs
@@ -82,6 +82,7 @@ let genTests = testList "Gen tests" [
             let! _ = Gen.int64 (Range.exponentialBounded ())
             return true
         }
+        |> Property.falseToFailure
         |> Property.check
 
     fableIgnore "uint64 can create exponentially bounded integer" <| fun _ ->
@@ -89,6 +90,7 @@ let genTests = testList "Gen tests" [
             let! _ = Gen.uint64 (Range.exponentialBounded ())
             return true
         }
+        |> Property.falseToFailure
         |> Property.check
 
     testCase "apply is chainable" <| fun _ ->

--- a/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
+++ b/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>

--- a/tests/Hedgehog.Tests/PropertyTests.fs
+++ b/tests/Hedgehog.Tests/PropertyTests.fs
@@ -11,6 +11,7 @@ let propertyTests = testList "Property tests" [
                 let! xs = Range.singleton 0 |> Gen.int32 |> Gen.list (Range.singleton 5) |> Gen.map ResizeArray
                 return false
             }
+            |> Property.falseToFailure
             |> Property.renderWith (PropertyConfig.withShrinks 0<shrinks> PropertyConfig.defaultConfig)
         Expect.isNotMatch report "\.\.\." "Abbreviation (...) found"
 
@@ -57,6 +58,7 @@ let propertyTests = testList "Property tests" [
             let! opt = Gen.constant () |> Gen.option
             return opt |> Option.isSome
         }
+        |> Property.falseToFailure
         |> Property.report
         |> Report.render
         |> ignore

--- a/tests/Hedgehog.Tests/ShrinkTests.fs
+++ b/tests/Hedgehog.Tests/ShrinkTests.fs
@@ -207,6 +207,7 @@ let shrinkTests = testList "Shrink tests" [
                 let! actual = Range.linear 1 1_000_000 |> Gen.int32
                 return actual < 500_000
             }
+            |> Property.falseToFailure
             |> Property.reportWith propConfig
         match report.Status with
         | Failed failureData ->


### PR DESCRIPTION
This PR is makes progress on issue #332.  This PR should be merged before PR #336 (which is still only a draft).  After this PR is merged, I will force push an update to the branch in that PR that includes a rebase on top of the branch in this PR.

The main point of this PR is to add `BindReturn` to the `Property` computational expression.  As [the corresponding RFC says](https://github.com/fsharp/fslang-design/blob/main/FSharp-5.0/FS-1063-support-letbang-andbang-for-applicative-functors.md#:~:text=nodes-,BindReturn%20-%20adds,Bind2Return,-%2C)
> - `BindReturn` - adds support and/or efficiency for `let! ... return`

That is preciously what we need to avoid testing non-shrunken inputs during rechecking.

One "controversial" thing this PR does is remove the `Return(bool)` method from the `Property` CE.  I removed it because having both this method and `BindReturn` were giving me compiler errors.  Removing `Return(bool)` was the only solution that I found.  Maybe there is another one we could use instead.  However, `Return(bool)` is not necessary.  It is syntactic sugar that allows the user to omit putting
```fsharp
|> Property.failOnFalse
```
after their CE instance.  Therefore, I think it is reasonable to remove this.