### PR TITLE
Update dev container and project files.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,10 +9,12 @@ RUN apt update && apt -y install --no-install-recommends --no-install-suggests \
  && apt -y clean \
  && rm -rf /var/lib/apt/lists/*
 
-RUN groupadd -g 1000 dev \
- && useradd -g 1000 -u 1000 -m -s /bin/bash dev \
+RUN groupadd --system dev \
+ && useradd --system --create-home --shell /bin/bash --gid dev dev \
  && mkdir -p /home/dev/.vscode-server/extensions \
  && mkdir -p /home/dev/.vscode-server/extensionsCache \
  && chown -R dev:dev /home/dev
 
 USER dev
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "dockerComposeFile": "docker-compose.yml",
-  "postAttachCommand": "rm -rf .ionide",
+  "postAttachCommand": "rm -rf .ionide && dotnet restore",
+  "remoteUser": "dev",
   "service": "dev",
   "workspaceFolder": "/workspace",
 

--- a/tests/Hedgehog.Linq.Tests/Hedgehog.Linq.Tests.csproj
+++ b/tests/Hedgehog.Linq.Tests/Hedgehog.Linq.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <ApplicationIcon />
     <OutputType>Library</OutputType>

--- a/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
+++ b/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>


### PR DESCRIPTION
Taken from #353. This removes the hard-coded UID/GID, fixes the startup command to also `dotnet restore`, and normalizes our test project files (`netcoreapp3.0` is going to be deprecated soon).