### PR TITLE
Add test for concat order in Tree.bind

### DIFF
--- a/src/Hedgehog/Tree.fs
+++ b/src/Hedgehog/Tree.fs
@@ -1,4 +1,4 @@
-﻿namespace Hedgehog
+namespace Hedgehog
 
 /// A rose tree which represents a random generated outcome, and all the ways
 /// in which it can be made smaller.
@@ -16,6 +16,9 @@ module Tree =
     /// be tried (i.e. there is no backtracking).
     let shrinks (Node (_, xs) : Tree<'a>) : seq<Tree<'a>> =
         xs
+
+    let create a children =
+        Node (a, children)
 
     /// Create a tree with a single outcome and no shrinks.
     let singleton (x : 'a) : Tree<'a> =
@@ -130,3 +133,11 @@ module Tree =
         renderList t
         |> Seq.reduce (fun a b ->
             a + System.Environment.NewLine + b)
+
+    let rec zip (Node (aData, aChildren), Node (bData, bChildren)) =
+        Node ((aData, bData), List.zip (Seq.toList aChildren) (Seq.toList bChildren) |> List.map zip)
+
+    let equals a b =
+        zip (a, b)
+        |> map (fun (a, b) -> a = b)
+        |> cata (fun a bs -> a && Seq.fold (&&) true bs)

--- a/src/Hedgehog/Tree.fs
+++ b/src/Hedgehog/Tree.fs
@@ -134,10 +134,10 @@ module Tree =
         |> Seq.reduce (fun a b ->
             a + System.Environment.NewLine + b)
 
-    let rec zip (Node (aData, aChildren), Node (bData, bChildren)) =
+    let rec internal zip (Node (aData, aChildren), Node (bData, bChildren)) =
         Node ((aData, bData), List.zip (Seq.toList aChildren) (Seq.toList bChildren) |> List.map zip)
 
-    let equals a b =
+    let internal equals a b =
         zip (a, b)
         |> map (fun (a, b) -> a = b)
         |> cata (fun a bs -> a && Seq.fold (&&) true bs)

--- a/tests/Hedgehog.Tests/TreeTests.fs
+++ b/tests/Hedgehog.Tests/TreeTests.fs
@@ -22,16 +22,14 @@ let treeTests = testList "Tree tests" [
         let expected =
             Tree.create
                 ("b", 1)
-                (seq {
-                    Tree.create
-                        ("a", 1)
-                        (seq {
-                            Tree.singleton
-                                ("a", 0)
-                        })
-                    Tree.singleton
-                        ("b", 0)
-                })
+                [ Tree.create
+                      ("a", 1)
+                      [ Tree.singleton
+                            ("a", 0)
+                      ]
+                  Tree.singleton
+                      ("b", 0)
+                ]
 
         true =! Tree.equals actual expected
 

--- a/tests/Hedgehog.Tests/TreeTests.fs
+++ b/tests/Hedgehog.Tests/TreeTests.fs
@@ -19,24 +19,21 @@ let treeTests = testList "Tree tests" [
                 iTree
                 |> Tree.map (fun i -> s, i))
 
-        let x = Tree.singleton ("b", 0)
-        let y =
-            Tree.singleton ("a", 1)
-            |> Tree.addChild (Tree.singleton ("a", 0))
         let expected =
-            Tree.singleton ("b", 1)
-            |> Tree.addChild x
-            |> Tree.addChild y
-        let actualString =
-            actual
-            |> Tree.map (sprintf "%A")
-            |> Tree.render
-        let expectedString =
-            expected
-            |> Tree.map (sprintf "%A")
-            |> Tree.render
-        //actual =! expected // unfortunately, this says the trees are disequal
-        actualString =! expectedString
+            Tree.create
+                ("b", 1)
+                (seq {
+                    Tree.create
+                        ("a", 1)
+                        (seq {
+                            Tree.singleton
+                                ("a", 0)
+                        })
+                    Tree.singleton
+                        ("b", 0)
+                })
+
+        true =! Tree.equals actual expected
 
 
     testCase "depth of tree with no subtrees is 0" <| fun _ ->

--- a/tests/Hedgehog.Tests/TreeTests.fs
+++ b/tests/Hedgehog.Tests/TreeTests.fs
@@ -35,7 +35,7 @@ let treeTests = testList "Tree tests" [
             expected
             |> Tree.map (sprintf "%A")
             |> Tree.render
-        //actual =! expected // unfortunely, this says the trees are disequal
+        //actual =! expected // unfortunately, this says the trees are disequal
         actualString =! expectedString
 
 


### PR DESCRIPTION
There are two ways in which the old and new children in `Tree.bind` can be concatenated.  As [discussed here](https://well-typed.com/blog/2019/05/integrated-shrinking/#:~:text=Although%20this%20version%20of%20join%20still%20satisfies%20the%20monad%20laws%2C%20it%20is%20strictly%20worse.), one of those ways is better than the other.

There is another tests that sort of covers this, but it is very indirect and sometimes passes (when the order is wrong).  That tests is 1greedy traversal with a predicate yields the perfect minimal shrink`.

This PR adds a specific and deterministic test to ensure that we are using the better order.