### PR TITLE
Add RecheckInfo to simplify recheck reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `BindReturn` to the `property` CE ([#364][364], [@TysonMN][TysonMN])
   - A breaking change.  Previously, returning a `bool` from a `property` CE (after using `let!`) caused the CE to have return type `Property<unit>`.  Now this results in a return type of `Property<bool>`.  The previous behavior can now be expressed by piping the `Property<bool>` instance into `Property.falseToFailure`.
 - Change recheck API to accept recheck data encoded as `string` ([#385][385], [@TysonMN][TysonMN])
+- Add `RecheckInfo` to simplify recheck reporting ([#386][386], [@TysonMN][TysonMN])
 
 ## Version 0.11.1 (2021-11-19)
 
@@ -183,6 +184,8 @@
 [porges]:
   https://github.com/porges
 
+[386]:
+  https://github.com/hedgehogqa/fsharp-hedgehog/pull/386
 [385]:
   https://github.com/hedgehogqa/fsharp-hedgehog/pull/385
 [384]:

--- a/src/Hedgehog/PropertyArgs.fs
+++ b/src/Hedgehog/PropertyArgs.fs
@@ -2,14 +2,14 @@ namespace Hedgehog
 
 [<Struct>]
 type PropertyArgs = internal {
-    RecheckType : RecheckType
+    Language : Language option
     RecheckData : RecheckData
 }
 
 module PropertyArgs =
 
     let init = {
-        RecheckType = RecheckType.FSharp
+        Language = Some Language.FSharp
         RecheckData = {
             Size = 0
             Seed = Seed.random ()


### PR DESCRIPTION
This really isn't an improvement on its own, but this will simplify PR #336.

`reportWith'` currently populates `Outcome.Failure.Status` with the return value from a call to `shrinkInput`.  With the optimized rechecking in PR #336, no shrinking occurs when rechecking.  Instead, `Outcome.Failure.Status` is populated after following the shrink path with an instance of `Status.Failed` that doesn't need to provide recheck data.