### PR TITLE
Fix introductory examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ open Hedgehog
 Once you have your import declaration set up, you can write a simple property:
 
 ```fsharp
-let propReverse : Property<Unit> =
+let propReverse : Property<bool> =
     property {
         let! xs = Gen.list (Range.linear 0 100) Gen.alpha
         return xs |> List.rev |> List.rev = xs

--- a/doc/index.md
+++ b/doc/index.md
@@ -39,7 +39,7 @@ property {
     let! xs = Range.constant 0 1000 |> Gen.int32 |> Gen.list (Range.linear 0 100)
     return List.rev (List.rev xs) = xs
 }
-|> Property.render
+|> Property.renderBool
 |> printfn "%s"
 
 +++ OK, passed 100 tests.


### PR DESCRIPTION
The example properties are of type `Property<bool>`, and thus the correct type annotation should be used as well as the correct render function. As they are now in the documentation (prior to this edit), neither of these example properties compile.