### PR TITLE
Anchor works in the website too

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -1,17 +1,16 @@
 ﻿# Tutorial
 
-* [Getting Started](#getting-started)
-  * [At a glance](#at-a-glance)
-  * [Integrated shrinking](#-integrated-shrinking-is-an-important-quality-of-hedgehog)
-* [Generators](#generators)
-  * [The `gen` expression](#-generators-can-also-be-created-using-the-gen-expression)
-* [Properties](#properties)
-  * [The `property` expression](#-properties-can-also-be-created-using-the-property-expression)
-  * [Custom Operations](#custom-operations)
+* [Getting Started](#Getting-Started)
+  * [At a glance](#At-a-glance)
+  * [Integrated shrinking](#-Integrated-shrinking-is-an-important-quality-of-Hedgehog)
+* [Generators](#Generators)
+* [Properties](#Properties)
+  * [The `gen` expression](#-Generators-can-also-be-created-using-the-gen-expression)
+  * [Custom Operations](#Custom-Operations)
     * [`counterexample`](#counterexample)
     * [`where`](#where)
-* [Integrations](#integrations)
-  * [Regex-constrained strings](#regex-constrained-strings)
+* [Integrations](#Integrations)
+  * [Regex-constrained strings](#Regex-constrained-strings)
 
 ### Getting Started
 


### PR DESCRIPTION
In the page https://hedgehogqa.github.io/fsharp-hedgehog/ the links in the table of content do not work, because of mismatches in the case (e.g. `getting-started` instead of `Getting-started`).

This PR fixes this.

I also noticed there was a duplicated link, which I removed.