### PR TITLE
Specify the YoloDev.Expecto.TestSdk package version to 0.14.3

### DIFF
--- a/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
+++ b/tests/Hedgehog.Tests/Hedgehog.Tests.fsproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Expecto" Version="10.*" />
     <PackageReference Include="Fable.Mocha" Version="2.17.0" />
-    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
+    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.14.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Update="FSharp.Core" Version="7.0.300" />
   </ItemGroup>


### PR DESCRIPTION
Starting from version 0.15.*, the YoloDev.Expecto.TestSdkpackage targets .NET 8. Since the test project is using .NET 6, it fails to build with newer versions. To ensure compatibility and successful builds, the package version is specified to 0.14.3, which supports .NET 6.