### PR TITLE
Update Hedgehog.fsproj to remove quick start link

### DIFF
--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -14,9 +14,6 @@ Hedgehog automatically generates a comprehensive array of test cases, exercising
 
 Generate hundreds of test cases automatically, exposing even the most insidious of corner cases.
 Failures are automatically simplified, giving developers coherent, intelligible error messages.
-
-To get started quickly, see the examples in
-https://github.com/hedgehogqa/fsharp-hedgehog/blob/master/doc/index.md
     </PackageDescription>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://hedgehogqa.github.io/fsharp-hedgehog/</PackageProjectUrl>


### PR DESCRIPTION
Removed quick start link from package description.

Project website already points to https://hedgehogqa.github.io/fsharp-hedgehog/.

See for example:
https://www.nuget.org/packages/Hedgehog/1.0.0-beta1