### PR TITLE
Use different seed for each property

### DIFF
--- a/src/Hedgehog/Property.fs
+++ b/src/Hedgehog/Property.fs
@@ -480,7 +480,7 @@ module Property =
     /// The report includes the number of tests run, discards, and failure information with shrunk counterexamples.
     /// This blocks until all tests complete.
     let reportWith (config : IPropertyConfig) (p : Property<unit>) : Report =
-        p |> reportWith' PropertyArgs.init config
+        p |> reportWith' (PropertyArgs.init ()) config
 
     /// Runs a property test with default configuration and returns a detailed report.
     /// By default, runs 100 tests. This blocks until all tests complete.
@@ -629,7 +629,7 @@ module Property =
     /// This is non-blocking and properly handles async properties without blocking threads.
     /// Use this when testing async code or when you need non-blocking test execution.
     let reportAsyncWith (config : IPropertyConfig) (p : Property<unit>) : Async<Report> =
-        p |> reportWithAsync' PropertyArgs.init config
+        p |> reportWithAsync' (PropertyArgs.init ()) config
 
     /// Runs a property test asynchronously with default configuration, returning an F# Async that produces a report.
     /// This is non-blocking and properly handles async properties without blocking threads.

--- a/src/Hedgehog/PropertyArgs.fs
+++ b/src/Hedgehog/PropertyArgs.fs
@@ -8,7 +8,7 @@ type PropertyArgs = internal {
 
 module PropertyArgs =
 
-    let init = {
+    let init () = {
         Language = Language.FSharp
         RecheckData = {
             Size = 0


### PR DESCRIPTION
I was looking at https://github.com/hedgehogqa/fsharp-hedgehog/issues/451 to understand why it happens.

Turns out it happens because `PropertyArgs.init` is a value, and not a funciton.
Which means that it _does_ start with the random seed, but _all_ the properties in a run use _the same_ random seed.

This causes different properties generating the same values.

@moodmosaic I am not sure if it is a bug or a feature. From my PoV it is a bug :)
If you agree, here is the fix.