### PR TITLE
Change to using SPDX identifier for nuget package license

### DIFF
--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -15,7 +15,7 @@ Hedgehog automatically generates a comprehensive array of test cases, exercising
 Generate hundreds of test cases automatically, exposing even the most insidious of corner cases.
 Failures are automatically simplified, giving developers coherent, intelligible error messages.
     </PackageDescription>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://hedgehogqa.github.io/fsharp-hedgehog/</PackageProjectUrl>
     <PackageIcon>hedgehog-logo.png</PackageIcon>
     <PackageIconUrl>https://github.com/hedgehogqa/fsharp-hedgehog/raw/master/img/hedgehog-logo.png</PackageIconUrl>
@@ -87,7 +87,7 @@ Failures are automatically simplified, giving developers coherent, intelligible 
   <ItemGroup>
     <PackageReference Include="TypeShape" Version="9.0.0" Condition="'$(FABLE_COMPILER)' == ''" />
   </ItemGroup>
-  
+
   <!-- https://fable.io/docs/your-fable-project/author-a-fable-library.html -->
   <ItemGroup>
     <None Include="*.fsproj; **\*.fs"


### PR DESCRIPTION
This just switches out how the license is exposed to an SPDX identifier.  The license file is still included in the nuget package. The xUnit and NUnit packages already employ this approach so this brings a little conformity too.