### PR TITLE
Add SourceLink

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "rollForward": "disable",
-    "version": "8.0.416"
+    "version": "8.0.416",
+    "rollForward": "latestFeature"
   }
 }

--- a/src/Hedgehog/Hedgehog.fsproj
+++ b/src/Hedgehog/Hedgehog.fsproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <IsPackable>true</IsPackable>
     <TargetFramework>net8.0</TargetFramework>
     <Version>2.0.3</Version>
     <Description>Release with confidence.</Description>
@@ -8,6 +9,8 @@
     <Copyright>Copyright © 2017</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DebugType>Embedded</DebugType>
+    <EmbedAllSources>True</EmbedAllSources>
     <PackageId>Hedgehog</PackageId>
     <PackageDescription>
 Hedgehog automatically generates a comprehensive array of test cases, exercising your software in ways human testers would never imagine.


### PR DESCRIPTION
Resolves #484

* Changes rollForward policy in global.json to allow repo to be opened with any .net sdk > 8.0.416
* Adds SourceLink, via embedded pdb to match Hedgehog.Xunit and Hedgehog.Nunit (turns out they already had sources bundled): https://github.com/dotnet/sourcelink#embed-in-assembly